### PR TITLE
Add semantic post-analysis pipeline for opcode naming

### DIFF
--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -11,6 +11,7 @@ from .knowledge import (
     MergeReport,
     ProfileAssessment,
     ReviewTask,
+    SemanticNamingReport,
     StackObservation,
 )
 from .cfg import ControlFlowGraphBuilder, ControlFlowGraph
@@ -33,6 +34,7 @@ __all__ = [
     "ProfileAssessment",
     "MergeReport",
     "ReviewTask",
+    "SemanticNamingReport",
     "StackObservation",
     "ControlFlowGraphBuilder",
     "ControlFlowGraph",

--- a/mbcdisasm/auto_analyze.py
+++ b/mbcdisasm/auto_analyze.py
@@ -41,6 +41,7 @@ def main() -> None:
         container = MbcContainer.load(mbc_path, adb_path, classifier=classifier)
         result = analyzer.analyze(container)
         merge_report = knowledge.merge_profiles(result.iter_profiles())
+        semantic_report = knowledge.apply_semantic_annotations()
         print(f"processed {mbc_path.name}: {result.total_instructions} instructions")
         if merge_report.updates:
             sample = ", ".join(
@@ -50,6 +51,14 @@ def main() -> None:
             if len(merge_report.updates) > 3:
                 sample += f", +{len(merge_report.updates) - 3} more"
             print(f"  learned stack patterns: {sample}")
+        if semantic_report.matches:
+            preview = ", ".join(
+                f"{match.key}->{match.prototype} ({match.score:.2f})"
+                for match in semantic_report.matches[:3]
+            )
+            if len(semantic_report.matches) > 3:
+                preview += f", +{len(semantic_report.matches) - 3} more"
+            print(f"  semantic assignments: {preview}")
         conflicts = merge_report.conflicts()
         if conflicts:
             names = ", ".join(c.key for c in conflicts[:5])

--- a/mbcdisasm/review_cli.py
+++ b/mbcdisasm/review_cli.py
@@ -77,6 +77,10 @@ def generate_review_package(
             min_samples=min_samples,
             confidence_threshold=confidence_threshold,
         )
+        knowledge.apply_semantic_annotations(
+            min_samples=min_samples,
+            score_threshold=confidence_threshold,
+        )
 
         status_counts = Counter()
         for assessment in merge_report.assessments:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -140,6 +140,7 @@ def test_merge_profiles_infers_manual_annotations(tmp_path):
     profile.following = Counter({"00:01": 4})
 
     report = knowledge.merge_profiles([profile], min_samples=3, confidence_threshold=0.5)
+    semantic_report = knowledge.apply_semantic_annotations(min_samples=3)
 
     metadata = knowledge.instruction_metadata("BB:00")
     assert metadata.mnemonic == "manual_literal"
@@ -147,7 +148,9 @@ def test_merge_profiles_infers_manual_annotations(tmp_path):
     assert metadata.stack_delta == 1
     assert metadata.operand_hint == "small"
 
-    update_fields = {update.field for update in report.updates if update.key == "BB:00"}
+    update_fields = {
+        update.field for update in semantic_report.updates if update.key == "BB:00"
+    }
     assert "name" in update_fields
     assert "manual_source" in update_fields
 
@@ -178,6 +181,7 @@ def test_manual_inference_handles_unknown_stack(tmp_path):
     profile.operand_types = Counter({"small": 8})
 
     report = knowledge.merge_profiles([profile], min_samples=3, confidence_threshold=0.5)
+    semantic_report = knowledge.apply_semantic_annotations(min_samples=3)
 
     metadata = knowledge.instruction_metadata("BB:00")
     assert metadata.mnemonic == "manual_literal"
@@ -185,7 +189,9 @@ def test_manual_inference_handles_unknown_stack(tmp_path):
     assert metadata.stack_delta == 1
     assert metadata.operand_hint == "small"
 
-    update_fields = {update.field for update in report.updates if update.key == "BB:00"}
+    update_fields = {
+        update.field for update in semantic_report.updates if update.key == "BB:00"
+    }
     assert "manual_source" in update_fields
 
 


### PR DESCRIPTION
## Summary
- add a semantic post-analysis pass that aggregates opcode profile evidence and applies manual naming with rationale reporting
- surface stack delta origins in disassembly outputs and expose the semantic report through the public API and CLI flows
- update automation scripts and tests to validate the new semantic annotation pipeline

## Testing
- pytest tests/test_knowledge.py tests/test_stack_gap_inventory.py

------
https://chatgpt.com/codex/tasks/task_e_68d92dfa14ec832f8243cc990c82925c