### PR TITLE
Write reconstructed Lua modules to files by default

### DIFF
--- a/mbc_lua_reconstruct.py
+++ b/mbc_lua_reconstruct.py
@@ -81,10 +81,9 @@ def main() -> None:
 
     module_text = reconstructor.render(functions)
 
-    if args.output:
-        args.output.write_text(module_text, "utf-8")
-    else:
-        print(module_text)
+    output_path = args.output or args.mbc.with_suffix(".lua")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(module_text, "utf-8")
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure `mbc_lua_reconstruct.py` writes reconstructed Lua output to a file
- default the output path to the .mbc input name with a .lua extension and create parent directories when needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9a9a3b98c832fb488eafff17be58a