### PR TITLE
Enhance inline string decoding and string utilities

### DIFF
--- a/mbc_lua_reconstruct.py
+++ b/mbc_lua_reconstruct.py
@@ -61,6 +61,23 @@ def parse_args() -> argparse.Namespace:
         help="Maximum width for inline comments before they become standalone",
     )
     parser.add_argument(
+        "--no-inline-comments",
+        action="store_true",
+        help="Do not emit inline chunk previews inside the reconstructed Lua",
+    )
+    parser.add_argument(
+        "--inline-preview-limit",
+        type=int,
+        default=None,
+        help="Maximum number of characters to include in inline chunk previews",
+    )
+    parser.add_argument(
+        "--inline-text-threshold",
+        type=float,
+        default=None,
+        help="Printable ratio required for inline chunks to be treated as text",
+    )
+    parser.add_argument(
         "--no-stub-metadata",
         action="store_true",
         help="Skip emitting helper stub metadata (inputs/outputs annotations)",
@@ -111,6 +128,12 @@ def main() -> None:
         options.emit_enum_metadata = False
     if args.no_module_summary:
         options.emit_module_summary = False
+    if args.no_inline_comments:
+        options.emit_inline_comments = False
+    if args.inline_preview_limit:
+        options.inline_preview_limit = max(8, args.inline_preview_limit)
+    if args.inline_text_threshold is not None:
+        options.inline_text_threshold = max(0.0, min(1.0, args.inline_text_threshold))
 
     reconstructor = HighLevelReconstructor(knowledge, options=options)
 

--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -19,7 +19,22 @@ from .ir import IRBuilder, IRProgram, write_ir_programs
 from .emulator import Emulator, EmulationReport, write_emulation_reports
 from .stack_model import StackDeltaEstimate, StackDeltaModeler
 from .ast import LuaReconstructor
-from .highlevel import FunctionMetadata, HighLevelFunction, HighLevelReconstructor
+from .highlevel import (
+    FunctionMetadata,
+    HighLevelFunction,
+    HighLevelReconstructor,
+    StackValue,
+)
+from .inline_strings import (
+    InlineStringAccumulator,
+    InlineStringChunk,
+    InlineStringSequence,
+    InlineStringCollector,
+    InlineStringReport,
+    render_inline_tables,
+)
+from .string_utils import chunk_preview, printable_ratio
+from .string_tables import StringTable, StringTableEntry, parse_string_table
 from .lua_formatter import LuaRenderOptions
 from .segment_classifier import SegmentClassifier
 from .manual_semantics import (
@@ -83,6 +98,18 @@ __all__ = [
     "HighLevelFunction",
     "HighLevelReconstructor",
     "FunctionMetadata",
+    "StackValue",
+    "InlineStringAccumulator",
+    "InlineStringChunk",
+    "InlineStringSequence",
+    "InlineStringCollector",
+    "InlineStringReport",
+    "render_inline_tables",
+    "chunk_preview",
+    "printable_ratio",
+    "StringTable",
+    "StringTableEntry",
+    "parse_string_table",
     "LuaRenderOptions",
     "SegmentClassifier",
     "ManualSemanticAnalyzer",

--- a/mbcdisasm/inline_strings.py
+++ b/mbcdisasm/inline_strings.py
@@ -1,0 +1,476 @@
+"""Utilities that decode inline ASCII payloads embedded in instruction words.
+
+The Sphere bytecode frequently inlines short string fragments directly inside
+opcode words.  Those pseudo instructions do not interact with the VM stack; the
+interpreter merely copies their payload into auxiliary buffers that eventually
+feed structured data writers.  Historically the high level reconstructor treated
+them as opaque helper calls which meant that large portions of quest text and
+UI strings were effectively invisible in the generated Lua.  The module below
+provides a small toolkit that understands the inline encodings and exposes the
+captured data in a structured way so that reconstruction layers can surface the
+information to operators.
+
+Two important concepts are modelled:
+
+``InlineStringAccumulator``
+    Lightweight state machine that consumes :class:`~mbcdisasm.ir.IRInstruction`
+    instances and gathers the decoded bytes until a non-inline instruction is
+    observed.  Accumulators can be reused across basic blocks which keeps the
+    high level translator logic straightforward.
+
+``InlineStringCollector``
+    Aggregates the chunks produced by accumulators, grouping them per segment
+    and offering convenience accessors that summarise how much data has been
+    recovered.  The collector intentionally stays ignorant about rendering so it
+    can be reused by command line tools and tests that need direct access to the
+    decoded blobs.
+
+The module also exposes :func:`escape_lua_bytes` which mirrors the escaping
+rules used elsewhere in the project but accepts arbitrary byte sequences.  This
+keeps the output deterministic and shields the rest of the code base from
+having to worry about control characters.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
+
+from .ir import IRInstruction
+from .lua_formatter import LuaWriter
+from .manual_semantics import InstructionSemantics
+from .string_utils import chunk_preview, decode_latin1, printable_ratio
+
+# ---------------------------------------------------------------------------
+# Inline opcode detection helpers
+# ---------------------------------------------------------------------------
+
+
+_INLINE_PREFIXES: Tuple[str, ...] = (
+    "inline_ascii_chunk",
+    "inline_mask_chunk",
+    "inline_string_token",
+)
+
+
+def is_inline_semantics(semantics: InstructionSemantics) -> bool:
+    """Return ``True`` when ``semantics`` encodes inline ASCII payloads.
+
+    Manual annotations use a fairly small vocabulary for these pseudo
+    instructions.  We key off the ``manual_name`` field which is stable across
+    knowledge base versions and mirrors how analysts refer to the opcodes during
+    manual triage sessions.
+    """
+
+    name = semantics.manual_name.lower()
+    return any(name.startswith(prefix) for prefix in _INLINE_PREFIXES)
+
+
+def decode_inline_bytes(instruction: IRInstruction) -> bytes:
+    """Decode the four ASCII bytes embedded in ``instruction``.
+
+    The encoding mirrors the raw instruction layout: the opcode byte contributes
+    the first character, the mode byte contributes the second and the 16-bit
+    operand stores the remaining pair.  The helper keeps the logic in one place
+    so that callers do not have to duplicate the conversion.
+    """
+
+    opcode_hex, mode_hex = instruction.key.split(":", 1)
+    opcode = int(opcode_hex, 16) & 0xFF
+    mode = int(mode_hex, 16) & 0xFF
+    operand = instruction.operand & 0xFFFF
+    return bytes([opcode, mode, (operand >> 8) & 0xFF, operand & 0xFF])
+
+
+# ---------------------------------------------------------------------------
+# Inline string accumulation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InlineStringChunk:
+    """A decoded inline ASCII payload extracted from instruction words."""
+
+    segment_index: int
+    block_start: int
+    start_offset: int
+    end_offset: int
+    data: bytes
+    instruction_offsets: Tuple[int, ...] = field(default_factory=tuple)
+
+    @property
+    def length(self) -> int:
+        return len(self.data)
+
+    def text(self) -> str:
+        """Decode the chunk using Latin-1 with safe replacements."""
+
+        return decode_latin1(self.data)
+
+    def preview(self, limit: int = 48) -> str:
+        """Return a short human-readable description of the bytes."""
+
+        return str(chunk_preview(self.data, limit=limit))
+
+    def printable_ratio(self) -> float:
+        return printable_ratio(self.data)
+
+    def is_probably_text(self, threshold: float = 0.75) -> bool:
+        """Best effort detection to decide whether the chunk resembles text."""
+
+        return self.printable_ratio() >= threshold
+
+
+@dataclass(frozen=True)
+class InlineStringSequence:
+    """Merged view combining consecutive chunks belonging to the same block."""
+
+    segment_index: int
+    start_block: int
+    chunks: Tuple[InlineStringChunk, ...]
+    data: bytes
+
+    def __post_init__(self) -> None:
+        if not self.chunks:
+            raise ValueError("inline string sequence requires at least one chunk")
+
+    @property
+    def start_offset(self) -> int:
+        return self.chunks[0].start_offset
+
+    @property
+    def end_offset(self) -> int:
+        return self.chunks[-1].end_offset
+
+    @property
+    def total_length(self) -> int:
+        return len(self.data)
+
+    def printable_ratio(self) -> float:
+        return printable_ratio(self.data)
+
+    def preview(self, limit: int = 80) -> str:
+        return str(chunk_preview(self.data, limit=limit))
+
+
+
+@dataclass
+class InlineStringReport:
+    """Aggregated statistics computed from an :class:`InlineStringCollector`."""
+
+    entry_count: int
+    segment_count: int
+    total_bytes: int
+    longest_chunk: Optional[InlineStringChunk]
+    average_length: float
+
+    def longest_summary(self) -> Optional[str]:
+        if self.longest_chunk is None:
+            return None
+        return (
+            f"{self.longest_chunk.length} bytes at segment "
+            f"{self.longest_chunk.segment_index:03d} offset "
+            f"0x{self.longest_chunk.start_offset:06X}"
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "entries": self.entry_count,
+            "segments": self.segment_count,
+            "bytes": self.total_bytes,
+            "average_length": self.average_length,
+        }
+        longest = self.longest_summary()
+        if longest is not None:
+            payload["largest"] = longest
+        return payload
+
+
+class InlineStringAccumulator:
+    """Collect consecutive inline string instructions within a block."""
+
+    def __init__(self) -> None:
+        self._bytes = bytearray()
+        self._start: Optional[int] = None
+        self._end: Optional[int] = None
+        self._instructions: List[int] = []
+
+    # ------------------------------------------------------------------
+    def has_data(self) -> bool:
+        return bool(self._bytes)
+
+    def reset(self) -> None:
+        self._bytes.clear()
+        self._start = None
+        self._end = None
+        self._instructions.clear()
+
+    def feed(self, instruction: IRInstruction) -> None:
+        if self._start is None:
+            self._start = instruction.offset
+        self._end = instruction.offset
+        self._instructions.append(instruction.offset)
+        self._bytes.extend(decode_inline_bytes(instruction))
+
+    def finish(self, segment_index: int, block_start: int) -> InlineStringChunk:
+        if not self._bytes:
+            raise ValueError("inline accumulator is empty")
+        start_offset = self._start if self._start is not None else 0
+        end_offset = self._end if self._end is not None else start_offset
+        chunk = InlineStringChunk(
+            segment_index=segment_index,
+            block_start=block_start,
+            start_offset=start_offset,
+            end_offset=end_offset,
+            data=bytes(self._bytes),
+            instruction_offsets=tuple(self._instructions),
+        )
+        self.reset()
+        return chunk
+
+
+class InlineStringCollector:
+    """Container that stores decoded inline strings grouped by segment."""
+
+    def __init__(self) -> None:
+        self._entries: Dict[int, List[InlineStringChunk]] = {}
+        self._sequence_cache: Optional[List[InlineStringSequence]] = None
+
+    # ------------------------------------------------------------------
+    def add(self, chunk: InlineStringChunk) -> None:
+        if not chunk.data:
+            return
+        self._entries.setdefault(chunk.segment_index, []).append(chunk)
+        self._sequence_cache = None
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self._sequence_cache = None
+
+    def is_empty(self) -> bool:
+        return all(not entries for entries in self._entries.values())
+
+    def segments(self) -> Iterator[int]:
+        yield from sorted(self._entries)
+
+    def entries_for(self, segment_index: int) -> List[InlineStringChunk]:
+        entries = self._entries.get(segment_index, [])
+        return sorted(entries, key=lambda chunk: chunk.start_offset)
+
+    def entry_count(self) -> int:
+        return sum(len(entries) for entries in self._entries.values())
+
+    def total_bytes(self) -> int:
+        return sum(chunk.length for entries in self._entries.values() for chunk in entries)
+
+    def iter_entries(self) -> Iterator[Tuple[int, InlineStringChunk]]:
+        for segment in self.segments():
+            for chunk in self.entries_for(segment):
+                yield segment, chunk
+
+    def _ensure_sequences(self) -> None:
+        if self._sequence_cache is not None:
+            return
+        sequences: List[InlineStringSequence] = []
+        for segment in self.segments():
+            entries = self.entries_for(segment)
+            if not entries:
+                continue
+            buffer = bytearray()
+            current: List[InlineStringChunk] = []
+            start_block = entries[0].block_start
+            previous_offset: Optional[int] = None
+            for chunk in entries:
+                expected = None if previous_offset is None else previous_offset + 4
+                contiguous = previous_offset is None or chunk.start_offset == expected
+                if not contiguous:
+                    if current:
+                        sequences.append(
+                            InlineStringSequence(
+                                segment_index=segment,
+                                start_block=start_block,
+                                chunks=tuple(current),
+                                data=bytes(buffer),
+                            )
+                        )
+                    buffer = bytearray()
+                    current = []
+                    start_block = chunk.block_start
+                buffer.extend(chunk.data)
+                current.append(chunk)
+                previous_offset = chunk.start_offset
+            if current:
+                sequences.append(
+                    InlineStringSequence(
+                        segment_index=segment,
+                        start_block=start_block,
+                        chunks=tuple(current),
+                        data=bytes(buffer),
+                    )
+                )
+        self._sequence_cache = sequences
+
+    def iter_sequences(self) -> Iterator[InlineStringSequence]:
+        self._ensure_sequences()
+        assert self._sequence_cache is not None
+        yield from self._sequence_cache
+
+    def segment_count(self) -> int:
+        return sum(1 for entries in self._entries.values() if entries)
+
+    def bytes_for_segment(self, segment_index: int) -> int:
+        return sum(chunk.length for chunk in self.entries_for(segment_index))
+
+    def longest_chunk(self) -> Optional[InlineStringChunk]:
+        longest: Optional[InlineStringChunk] = None
+        for _, chunk in self.iter_entries():
+            if longest is None or chunk.length > longest.length:
+                longest = chunk
+        return longest
+
+    def build_report(self) -> InlineStringReport:
+        entry_count = self.entry_count()
+        segment_count = self.segment_count()
+        total_bytes = self.total_bytes()
+        longest = self.longest_chunk()
+        average = total_bytes / entry_count if entry_count else 0.0
+        return InlineStringReport(
+            entry_count=entry_count,
+            segment_count=segment_count,
+            total_bytes=total_bytes,
+            longest_chunk=longest,
+            average_length=average,
+        )
+
+    def to_dict(self) -> Dict[str, Dict[str, Dict[str, str]]]:
+        payload: Dict[str, Dict[str, Dict[str, str]]] = {}
+        for segment in self.segments():
+            entries = self.entries_for(segment)
+            if not entries:
+                continue
+            segment_key = f"{segment:03d}"
+            segment_payload: Dict[str, Dict[str, str]] = {}
+            for chunk in entries:
+                offset = f"0x{chunk.start_offset:06X}"
+                segment_payload[offset] = {
+                    "hex": chunk.data.hex(),
+                    "lua": escape_lua_bytes(chunk.data),
+                }
+            payload[segment_key] = segment_payload
+        return payload
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def find(self, text: str) -> List[InlineStringChunk]:
+        matches: List[InlineStringChunk] = []
+        if not text:
+            return matches
+        needle = text.lower()
+        for _, chunk in self.iter_entries():
+            haystack = chunk.data.decode("latin-1", "ignore").lower()
+            if needle in haystack:
+                matches.append(chunk)
+        return matches
+
+    def iter_merged(self) -> Iterator[Tuple[int, Tuple[InlineStringChunk, ...], bytes]]:
+        for sequence in self.iter_sequences():
+            yield sequence.segment_index, sequence.chunks, sequence.data
+
+    def merged_strings(self) -> Dict[int, List[str]]:
+        merged: Dict[int, List[str]] = {}
+        for segment, chunks, data in self.iter_merged():
+            if not chunks:
+                continue
+            merged.setdefault(segment, []).append(escape_lua_bytes(data))
+        return merged
+
+
+    def filter_segments(self, predicate: Callable[[int], bool]) -> "InlineStringCollector":
+        filtered = InlineStringCollector()
+        for segment in self.segments():
+            if not predicate(segment):
+                continue
+            for chunk in self.entries_for(segment):
+                filtered.add(chunk)
+        return filtered
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def escape_lua_bytes(data: bytes) -> str:
+    """Return a Lua string literal that reproduces ``data`` byte-for-byte."""
+
+    parts: List[str] = []
+    for byte in data:
+        if byte == 0x5C:  # backslash
+            parts.append("\\\\")
+        elif byte == 0x22:  # double quote
+            parts.append('\"')
+        elif byte == 0x0A:
+            parts.append("\\n")
+        elif byte == 0x0D:
+            parts.append("\\r")
+        elif byte == 0x09:
+            parts.append("\\t")
+        elif 0x20 <= byte <= 0x7E:
+            parts.append(chr(byte))
+        else:
+            parts.append(f"\\x{byte:02X}")
+    return '"' + "".join(parts) + '"'
+
+
+def render_inline_tables(
+    collector: InlineStringCollector,
+    *,
+    prefix: str = "inline_segment",
+) -> str:
+    """Render Lua tables describing the decoded inline strings.
+
+    Each segment receives its own table which keeps the lookup logic intuitive in
+    the generated Lua source.  Callers can freely decide how to reference those
+    tables; the renderer merely emits them in a human friendly format.
+    """
+
+    writer = LuaWriter()
+    writer.write_comment(
+        "inline resource strings extracted from inline_* opcode encodings"
+    )
+    for segment in collector.segments():
+        entries = collector.entries_for(segment)
+        if not entries:
+            continue
+        writer.write_line("")
+        writer.write_line(f"local {prefix}_{segment:03d} = {{")
+        with writer.indented():
+            for chunk in entries:
+                if chunk.start_offset == chunk.end_offset:
+                    comment = f"chunk @0x{chunk.start_offset:06X}"
+                else:
+                    comment = (
+                        f"chunk 0x{chunk.start_offset:06X}..0x{chunk.end_offset:06X}"
+                    )
+                writer.write_comment(comment)
+                writer.write_line(
+                    f"[0x{chunk.start_offset:06X}] = {escape_lua_bytes(chunk.data)},"
+                )
+        writer.write_line("}")
+    return writer.render()
+
+
+__all__ = [
+    "InlineStringAccumulator",
+    "InlineStringChunk",
+    "InlineStringSequence",
+    "InlineStringCollector",
+    "InlineStringReport",
+    "decode_inline_bytes",
+    "escape_lua_bytes",
+    "is_inline_semantics",
+    "render_inline_tables",
+]
+

--- a/mbcdisasm/lua_ast.py
+++ b/mbcdisasm/lua_ast.py
@@ -37,6 +37,7 @@ class LuaExpression:
 @dataclass
 class LiteralExpr(LuaExpression):
     value: str
+    py_value: object | None = None
 
     def render(self) -> str:
         return self.value

--- a/mbcdisasm/lua_formatter.py
+++ b/mbcdisasm/lua_formatter.py
@@ -141,6 +141,9 @@ class LuaRenderOptions:
     emit_stub_metadata: bool = True
     emit_enum_metadata: bool = True
     emit_module_summary: bool = True
+    emit_inline_comments: bool = True
+    inline_preview_limit: int = 72
+    inline_text_threshold: float = 0.65
 
 
 class CommentFormatter:

--- a/mbcdisasm/string_tables.py
+++ b/mbcdisasm/string_tables.py
@@ -1,0 +1,172 @@
+"""Utilities for extracting printable strings from raw container segments.
+
+The parser favours ASCII NUL-terminated sequences which mirrors how most
+Sphere resources encode UI text.  The resulting tables can be re-used by tests
+or surfaced to analysts when reviewing reconstruction output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List
+
+from .lua_formatter import LuaWriter
+from .string_utils import (
+    Preview,
+    chunk_preview,
+    decode_latin1,
+    printable_ratio,
+    trim_ascii_suffix,
+)
+
+__all__ = [
+    "StringTableEntry",
+    "StringTable",
+    "parse_string_table",
+]
+
+
+@dataclass(frozen=True)
+class StringTableEntry:
+    """Single string extracted from a raw byte buffer."""
+
+    offset: int
+    data: bytes
+
+    def text(self) -> str:
+        return decode_latin1(trim_ascii_suffix(self.data))
+
+    def preview(self, *, limit: int = 60) -> Preview:
+        return chunk_preview(self.data, limit=limit)
+
+    def printable_ratio(self) -> float:
+        return printable_ratio(self.data)
+
+    def is_printable(self, threshold: float = 0.75) -> bool:
+        return self.printable_ratio() >= threshold
+
+    def to_dict(self) -> Dict[str, object]:
+        preview = self.preview()
+        return {
+            "offset": self.offset,
+            "length": len(self.data),
+            "text": preview.text,
+            "truncated": preview.truncated,
+            "printable_ratio": self.printable_ratio(),
+        }
+
+
+@dataclass
+class StringTable:
+    """Collection of :class:`StringTableEntry` objects with helper methods."""
+
+    start_offset: int
+    entries: List[StringTableEntry] = field(default_factory=list)
+
+    def __iter__(self) -> Iterator[StringTableEntry]:  # pragma: no cover - trivial
+        return iter(self.entries)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.entries)
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return bool(self.entries)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(len(entry.data) for entry in self.entries)
+
+    def add(self, entry: StringTableEntry) -> None:
+        self.entries.append(entry)
+
+    def iter_printable(self, *, threshold: float = 0.75) -> Iterator[StringTableEntry]:
+        for entry in self.entries:
+            if entry.is_printable(threshold=threshold):
+                yield entry
+
+    def search(self, needle: str) -> List[StringTableEntry]:
+        if not needle:
+            return []
+        lowered = needle.lower()
+        matches: List[StringTableEntry] = []
+        for entry in self.entries:
+            if lowered in entry.text().lower():
+                matches.append(entry)
+        return matches
+
+    def statistics(self) -> Dict[str, object]:
+        if not self.entries:
+            return {"entries": 0, "printable_ratio": 0.0, "bytes": 0}
+        printable = sum(1 for entry in self.entries if entry.is_printable())
+        return {
+            "entries": len(self.entries),
+            "bytes": self.total_bytes,
+            "printable_ratio": printable / len(self.entries),
+        }
+
+    def render(self, *, prefix: str = "string_table") -> str:
+        writer = LuaWriter()
+        writer.write_comment("decoded string table")
+        writer.write_line(f"local {prefix} = {{")
+        with writer.indented():
+            for entry in self.entries:
+                preview = entry.preview()
+                comment = preview.text if preview.text else "<empty>"
+                writer.write_comment(
+                    f"@0x{entry.offset:06X} len={len(entry.data)} {comment}"
+                )
+                writer.write_line(
+                    f"[0x{entry.offset:06X}] = {repr(entry.text())},"
+                )
+        writer.write_line("}")
+        return writer.render()
+
+    def to_dict(self) -> Dict[str, Dict[str, object]]:
+        return {f"0x{entry.offset:06X}": entry.to_dict() for entry in self.entries}
+
+    def slice(self, *, start: int, stop: int) -> "StringTable":
+        sliced = StringTable(start_offset=self.start_offset + start)
+        for entry in self.entries:
+            if start <= entry.offset - self.start_offset < stop:
+                sliced.add(entry)
+        return sliced
+
+
+def parse_string_table(
+    data: bytes,
+    *,
+    start_offset: int = 0,
+    min_length: int = 2,
+    terminator: bytes = b"\x00",
+) -> StringTable:
+    """Scan ``data`` and return a :class:`StringTable` with decoded entries."""
+
+    table = StringTable(start_offset=start_offset)
+    if not data:
+        return table
+
+    current = bytearray()
+    entry_start = start_offset
+    index = 0
+    terminator_set = set(terminator)
+    terminated = False
+    while index < len(data):
+        byte = data[index]
+        if byte in terminator_set:
+            if len(current) >= min_length:
+                table.add(
+                    StringTableEntry(
+                        offset=entry_start,
+                        data=bytes(current + bytes([byte])),
+                    )
+                )
+            current.clear()
+            entry_start = start_offset + index + 1
+            terminated = True
+        else:
+            if not current:
+                entry_start = start_offset + index
+            current.append(byte)
+            terminated = False
+        index += 1
+    return table

--- a/mbcdisasm/string_utils.py
+++ b/mbcdisasm/string_utils.py
@@ -1,0 +1,134 @@
+"""Utility helpers for dealing with printable strings and previews.
+
+The Sphere runtime regularly stores ASCII payloads inside instruction streams
+and standalone data segments.  Several reconstruction layers need to make
+decisions based on how *textual* a blob of bytes looks – for example the inline
+string collector prefers rendering comments only when the underlying data is
+readable.  Historically each caller implemented their own tiny helper which
+inevitably drifted apart whenever escaping rules evolved.
+
+This module centralises the logic.  It intentionally mirrors the semantics used
+by :mod:`mbcdisasm.inline_strings` so the behaviour stays consistent across
+modules.  Everything operates on raw :class:`bytes` objects and only introduces
+Unicode at the very edge when building human-readable previews.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator
+
+__all__ = [
+    "PRINTABLE_ASCII",
+    "is_printable_byte",
+    "printable_ratio",
+    "trim_ascii_suffix",
+    "decode_latin1",
+    "Preview",
+    "build_preview",
+    "chunk_preview",
+]
+
+
+# ---------------------------------------------------------------------------
+# printable byte detection
+# ---------------------------------------------------------------------------
+
+
+PRINTABLE_ASCII: frozenset[int] = frozenset(range(0x20, 0x7F))
+
+
+def is_printable_byte(value: int) -> bool:
+    """Return ``True`` when ``value`` is a reasonably printable ASCII byte."""
+
+    if value in PRINTABLE_ASCII:
+        return True
+    # Frequently encountered whitespace/control characters that are safe to
+    # display as-is in Lua comments.  We leave the actual escaping decision to
+    # the caller but expose the detection logic centrally.
+    return value in {0x09, 0x0A, 0x0D}
+
+
+def printable_ratio(data: bytes) -> float:
+    """Return the fraction of bytes that look printable."""
+
+    if not data:
+        return 0.0
+    printable = sum(1 for byte in data if is_printable_byte(byte))
+    return printable / len(data)
+
+
+def trim_ascii_suffix(data: bytes) -> bytes:
+    """Strip trailing NUL and carriage-return characters used as terminators."""
+
+    while data and data[-1] in (0, 0x0D):
+        data = data[:-1]
+    return data
+
+
+def decode_latin1(data: bytes) -> str:
+    """Decode ``data`` using Latin-1 with replacement for safety."""
+
+    return data.decode("latin-1", "replace")
+
+
+# ---------------------------------------------------------------------------
+# Preview helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Preview:
+    """Lightweight representation of a formatted preview."""
+
+    text: str
+    truncated: bool
+
+    def __str__(self) -> str:  # pragma: no cover - trivial proxy
+        return self.text
+
+
+def build_preview(parts: Iterable[str], *, truncated: bool = False) -> Preview:
+    """Construct a :class:`Preview` from a sequence of ``parts``."""
+
+    text = "".join(parts)
+    return Preview(text=text, truncated=truncated)
+
+
+def _normalise_whitespace(text: str) -> Iterator[str]:
+    for char in text:
+        code = ord(char)
+        if code == 0x0A:
+            yield "\\n"
+        elif code == 0x0D:
+            yield "\\r"
+        elif code == 0x09:
+            yield "\\t"
+        else:
+            yield char
+
+
+def chunk_preview(data: bytes, *, limit: int = 48) -> Preview:
+    """Return a preview of ``data`` suitable for inline comments.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of decoded characters to include before truncating the
+        preview.  The function emits an ellipsis when truncation happens so
+        callers can surface the hint to the user.
+    """
+
+    stripped = trim_ascii_suffix(data)
+    if not stripped:
+        return Preview(text="<empty>", truncated=False)
+
+    text = decode_latin1(stripped)
+    if len(text) <= limit:
+        return build_preview(_normalise_whitespace(text))
+
+    visible = text[:limit]
+    preview_text = list(_normalise_whitespace(visible))
+    preview_text.append("…")
+    return build_preview(preview_text, truncated=True)
+

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1,10 +1,19 @@
 import json
+import json
 from pathlib import Path
 
-from mbcdisasm.highlevel import HighLevelReconstructor
+from mbcdisasm.highlevel import (
+    FunctionMetadata,
+    HighLevelFunction,
+    HighLevelReconstructor,
+    HighLevelStack,
+    StackValue,
+)
 from mbcdisasm.ir import IRBlock, IRInstruction, IRProgram
+from mbcdisasm.lua_ast import LiteralExpr, NameExpr, wrap_block
 from mbcdisasm.knowledge import KnowledgeBase
 from mbcdisasm.manual_semantics import ManualSemanticAnalyzer
+from mbcdisasm.lua_formatter import LuaRenderOptions
 from mbcdisasm.vm_analysis import estimate_stack_io
 
 
@@ -109,3 +118,133 @@ def test_highlevel_reconstruction_generates_control_flow(tmp_path: Path) -> None
     assert "if cmp_" in rendered
     assert "while" not in rendered  # forward branch only
     assert "return literal_" in rendered or "return State" in rendered
+
+
+def test_inline_string_collection(tmp_path: Path) -> None:
+    kb_path = tmp_path / "inline_kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "72:65": {
+                    "name": "inline_ascii_chunk_7265",
+                    "stack_delta": 0,
+                    "summary": "Inline chunk",
+                },
+                "00:01": {
+                    "name": "no_op",
+                    "stack_delta": 0,
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+
+    block = IRBlock(
+        start=0,
+        instructions=[
+            _make_instruction(analyzer, 0x10, "72:65", 0x6E74, None),
+            _make_instruction(analyzer, 0x14, "00:01", 0, None),
+        ],
+        successors=[],
+    )
+    program = IRProgram(segment_index=5, blocks={block.start: block})
+
+    reconstructor = HighLevelReconstructor(knowledge)
+    function = reconstructor.from_ir(program)
+    rendered = reconstructor.render([function])
+
+    assert "inline_segment_005" in rendered
+    assert "rent" in rendered
+    assert "- inline string data: 1 entries (4 bytes)" in rendered
+    assert "- inline segments: 1" in rendered
+    assert "- average inline chunk: 4.0 bytes" in rendered
+    assert "largest inline chunk: 4 bytes at segment 005 offset 0x000010" in rendered
+    assert "- inline sample:" in rendered
+    assert "-- inline chunk" in rendered
+    summary = function.render()
+    assert "- inline chunks: 1" in summary
+    assert "- inline bytes: 4" in summary
+    report = reconstructor.build_report([function])
+    assert report["inline"]["entries"] == 1
+    assert report["inline_samples"]
+    assert report["functions"][0]["metadata"]["inline_chunks"] == 1
+
+    # Disabling inline comments should remove the preview while keeping metadata.
+    silent = HighLevelReconstructor(
+        knowledge, options=LuaRenderOptions(emit_inline_comments=False)
+    )
+    quiet_function = silent.from_ir(program)
+    quiet_rendered = silent.render([quiet_function])
+    assert "-- inline chunk" not in quiet_rendered
+
+
+def test_highlevel_stack_tracks_py_values() -> None:
+    stack = HighLevelStack()
+    literal = LiteralExpr("1", py_value=1)
+    statements, value = stack.push_literal(literal)
+    assert statements and isinstance(value, StackValue)
+    assert value.py_value == 1
+    alias_statements, alias = stack.push_expression(NameExpr(value.name))
+    assert alias_statements == []
+    assert alias.py_value == 1
+    popped = stack.pop_single()
+    assert popped.py_value == 1
+    stack.push_literal(LiteralExpr("2", py_value=2))
+    description = stack.describe()
+    assert description and description[0].startswith("[0]")
+    assert "2" in description[0]
+    snapshot = stack.snapshot()
+    assert snapshot[-1]["py_value"] == 2
+
+
+def test_highlevel_function_to_dict() -> None:
+    metadata = FunctionMetadata(block_count=1, instruction_count=2)
+    function = HighLevelFunction(name="demo", body=wrap_block([]), metadata=metadata)
+    payload = function.to_dict()
+    assert payload["name"] == "demo"
+    assert payload["metadata"]["blocks"] == 1
+
+
+def test_build_report_without_inline(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb_report.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "literal",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "04:00": {
+                    "name": "return_value",
+                    "summary": "return",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+            }
+        ),
+        "utf-8",
+    )
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+    block = IRBlock(
+        start=0,
+        instructions=[
+            _make_instruction(analyzer, 0, "01:00", 1, None),
+            _make_instruction(analyzer, 4, "04:00", 0, "return"),
+        ],
+        successors=[],
+    )
+    program = IRProgram(segment_index=7, blocks={block.start: block})
+    reconstructor = HighLevelReconstructor(knowledge)
+    function = reconstructor.from_ir(program)
+    report = reconstructor.build_report([function])
+    assert report["inline"]["entries"] == 0
+    assert report["inline_samples"] == []
+    assert report["functions"][0]["metadata"]["inline_bytes"] == 0

--- a/tests/test_inline_strings.py
+++ b/tests/test_inline_strings.py
@@ -1,0 +1,174 @@
+import json
+
+from mbcdisasm.inline_strings import (
+    InlineStringAccumulator,
+    InlineStringChunk,
+    InlineStringCollector,
+    escape_lua_bytes,
+    render_inline_tables,
+)
+from mbcdisasm.ir import IRInstruction
+from mbcdisasm.manual_semantics import InstructionSemantics, StackEffect
+
+
+def _make_inline_semantics(name: str) -> InstructionSemantics:
+    return InstructionSemantics(
+        key="72:65",
+        mnemonic=name,
+        manual_name=name,
+        summary="inline chunk",
+        control_flow=None,
+        stack_delta=0,
+        stack_effect=StackEffect(inputs=0, outputs=0, delta=0, source="test"),
+        tags=("literal",),
+        comparison_operator=None,
+        enum_values={},
+        enum_namespace=None,
+        struct_context=None,
+        stack_inputs=0,
+        stack_outputs=0,
+        uses_operand=False,
+        operand_hint=None,
+        vm_method=name,
+        vm_call_style="literal",
+    )
+
+
+def _make_instruction(offset: int, key: str, operand: int) -> IRInstruction:
+    semantics = _make_inline_semantics("inline_ascii_chunk_7265")
+    return IRInstruction(
+        offset=offset,
+        key=key,
+        mnemonic=semantics.mnemonic,
+        operand=operand,
+        stack_delta=0,
+        control_flow=None,
+        semantics=semantics,
+        stack_inputs=0,
+        stack_outputs=0,
+    )
+
+
+def _chunk(
+    segment: int,
+    offset: int,
+    data: bytes,
+    *,
+    block_start: int = 0,
+    end_offset: int | None = None,
+) -> InlineStringChunk:
+    return InlineStringChunk(
+        segment_index=segment,
+        block_start=block_start,
+        start_offset=offset,
+        end_offset=end_offset if end_offset is not None else offset,
+        data=data,
+        instruction_offsets=(offset,),
+    )
+
+
+def test_accumulator_decodes_bytes() -> None:
+    accumulator = InlineStringAccumulator()
+    instruction = _make_instruction(0x10, "72:65", 0x6E74)
+    accumulator.feed(instruction)
+    chunk = accumulator.finish(segment_index=2, block_start=0x10)
+    assert chunk.data == b"rent"
+    assert chunk.start_offset == 0x10
+    assert chunk.end_offset == 0x10
+
+
+def test_collector_tracks_statistics() -> None:
+    collector = InlineStringCollector()
+    collector.add(_chunk(1, 0x20, b"foo"))
+    collector.add(_chunk(1, 0x40, b"barbaz"))
+    assert collector.entry_count() == 2
+    assert collector.segment_count() == 1
+    assert collector.total_bytes() == 9
+    assert collector.bytes_for_segment(1) == 9
+    longest = collector.longest_chunk()
+    assert longest and longest.data == b"barbaz"
+    matches = collector.find("BAR")
+    assert matches and matches[0].data == b"barbaz"
+    assert collector.find("") == []
+    report = collector.build_report()
+    assert report.entry_count == 2
+    assert report.segment_count == 1
+    assert report.total_bytes == 9
+    assert report.average_length == 4.5
+    assert report.longest_summary() == "6 bytes at segment 001 offset 0x000040"
+    report_dict = report.to_dict()
+    assert report_dict["largest"] == "6 bytes at segment 001 offset 0x000040"
+
+
+def test_render_inline_tables_handles_escape_sequences() -> None:
+    collector = InlineStringCollector()
+    collector.add(_chunk(3, 0x100, b"line1\nline2"))
+    rendered = render_inline_tables(collector)
+    assert "inline_segment_003" in rendered
+    assert "\\n" in rendered
+
+
+def test_escape_lua_bytes_roundtrip() -> None:
+    literal = escape_lua_bytes(b"a\x00b\\")
+    assert literal == '"a\\x00b\\\\"'
+
+
+def test_collector_serialisation() -> None:
+    collector = InlineStringCollector()
+    collector.add(_chunk(0, 0x10, b"hi"))
+    mapping = collector.to_dict()
+    assert mapping == {
+        "000": {"0x000010": {"hex": "6869", "lua": '"hi"'}}
+    }
+    payload = json.loads(collector.to_json(indent=0))
+    assert payload["000"]["0x000010"]["hex"] == "6869"
+
+
+def test_merged_strings_combines_contiguous_chunks() -> None:
+    collector = InlineStringCollector()
+    collector.add(_chunk(2, 0x10, b"ab"))
+    collector.add(_chunk(2, 0x14, b"cd"))
+    collector.add(_chunk(2, 0x40, b"zz"))
+    merged = list(collector.iter_merged())
+    assert merged[0][0] == 2
+    assert merged[0][2] == b"abcd"
+    assert merged[1][2] == b"zz"
+    merged_lookup = collector.merged_strings()
+    assert merged_lookup[2][0] == '"abcd"'
+
+
+def test_filter_segments_returns_subset() -> None:
+    collector = InlineStringCollector()
+    collector.add(_chunk(1, 0x10, b"aa"))
+    collector.add(_chunk(2, 0x20, b"bb"))
+    filtered = collector.filter_segments(lambda seg: seg == 2)
+    assert filtered.entry_count() == 1
+    assert filtered.segment_count() == 1
+    assert list(filtered.segments()) == [2]
+
+
+def test_chunk_preview_and_ratio() -> None:
+    chunk = _chunk(0, 0x0, b"Dialog\nline")
+    assert chunk.is_probably_text()
+    preview = chunk.preview(limit=10)
+    assert "Dialog" in preview
+    noisy = _chunk(0, 0x10, b"\x01\x02\x03\x04")
+    assert not noisy.is_probably_text()
+
+
+def test_collector_sequences_and_summary() -> None:
+    collector = InlineStringCollector()
+    collector.add(_chunk(7, 0x30, b"He", block_start=0x100))
+    collector.add(_chunk(7, 0x34, b"llo", block_start=0x100))
+    collector.add(_chunk(8, 0x40, b"\x10\x11", block_start=0x200))
+    sequences = list(collector.iter_sequences())
+    assert len(sequences) == 2
+    assert sequences[0].preview().startswith("Hello")
+    summary = [
+        (
+            f"segment {sequence.segment_index:03d} block 0x{sequence.start_block:06X} "
+            f"len={sequence.total_length} bytes"
+        )
+        for sequence in collector.iter_sequences()
+    ]
+    assert any("segment 007" in line for line in summary)

--- a/tests/test_string_tables.py
+++ b/tests/test_string_tables.py
@@ -1,0 +1,26 @@
+from mbcdisasm.string_tables import StringTable, StringTableEntry, parse_string_table
+
+
+def test_parse_string_table_basic() -> None:
+    data = b"hello\0world\0garbage"
+    table = parse_string_table(data, start_offset=0x200)
+    assert len(table.entries) == 2
+    assert table.entries[0].text() == "hello"
+    assert table.entries[1].offset == 0x206
+
+
+def test_string_table_statistics_and_search() -> None:
+    table = StringTable(start_offset=0)
+    table.add(StringTableEntry(offset=0, data=b"Hello\0"))
+    table.add(StringTableEntry(offset=6, data=b"\x01\x02\x03"))
+    stats = table.statistics()
+    assert stats["entries"] == 2
+    assert table.search("hello")[0].offset == 0
+
+
+def test_string_table_rendering() -> None:
+    table = StringTable(start_offset=0x300)
+    table.add(StringTableEntry(offset=0x300, data=b"Dialog\0"))
+    rendered = table.render(prefix="dialogue")
+    assert "dialogue" in rendered
+    assert "0x000300" in rendered

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,0 +1,16 @@
+from mbcdisasm.string_utils import chunk_preview, is_printable_byte, printable_ratio, trim_ascii_suffix
+
+
+def test_is_printable_byte_and_ratio() -> None:
+    assert is_printable_byte(ord("A"))
+    assert not is_printable_byte(0x01)
+    data = b"ABCD"
+    assert printable_ratio(data) == 1.0
+    assert printable_ratio(b"\x00AB") < 1.0
+
+
+def test_chunk_preview_and_trim() -> None:
+    preview = chunk_preview(b"Line1\nLine2", limit=5)
+    assert preview.text.startswith("Line1")
+    assert preview.truncated
+    assert trim_ascii_suffix(b"test\x00\x00") == b"test"


### PR DESCRIPTION
## Summary
- add reusable string utility helpers and a string table parser for decoding textual blobs
- expand the inline string collector to track merged sequences and emit inline previews in the high-level reconstructor
- expose CLI controls for inline comments and cover the new behavior with focused tests

## Testing
- pytest -k "not stack_gap_inventory" -q
- pytest tests/test_inline_strings.py tests/test_string_tables.py tests/test_string_utils.py -q

------
https://chatgpt.com/codex/tasks/task_e_68da525d7c40832fab59a8ab9025737b