### PR TITLE
Integrate string analysis into Lua reconstruction heuristics

### DIFF
--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -34,6 +34,12 @@ from .manual_semantics import (
     ManualSemanticAnalyzer,
     StackEffect,
 )
+from .string_analysis import (
+    StringClassifier,
+    StringInsight,
+    summarise_insights,
+    token_histogram,
+)
 from .vm_analysis import (
     VMBlockTrace,
     VMInstructionState,
@@ -90,6 +96,10 @@ __all__ = [
     "StringLiteralSequence",
     "FunctionMetadata",
     "LuaRenderOptions",
+    "StringClassifier",
+    "StringInsight",
+    "summarise_insights",
+    "token_histogram",
     "SegmentClassifier",
     "ManualSemanticAnalyzer",
     "InstructionSemantics",

--- a/mbcdisasm/lua_formatter.py
+++ b/mbcdisasm/lua_formatter.py
@@ -141,6 +141,7 @@ class LuaRenderOptions:
     emit_stub_metadata: bool = True
     emit_enum_metadata: bool = True
     emit_module_summary: bool = True
+    emit_string_catalog: bool = True
 
 
 class CommentFormatter:

--- a/mbcdisasm/string_analysis.py
+++ b/mbcdisasm/string_analysis.py
@@ -1,0 +1,277 @@
+"""Utility helpers for analysing and classifying recovered string literals."""
+
+from __future__ import annotations
+
+import math
+import re
+import string
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, List, Sequence, Tuple
+
+_PRINTABLE = set(string.printable)
+_WORD_PATTERN = re.compile(r"[A-Za-z0-9_]+")
+_CAMEL_BOUNDARY = re.compile(r"(?<![A-Z])[A-Z](?=[a-z])")
+
+
+@dataclass(frozen=True)
+class StringInsight:
+    """Classification metadata describing an analysed string literal."""
+
+    text: str
+    tokens: Tuple[str, ...] = field(default_factory=tuple)
+    classification: str = "unknown"
+    confidence: float = 0.0
+    hints: Tuple[str, ...] = field(default_factory=tuple)
+    entropy: float = 0.0
+    case_style: str = "neutral"
+    printable_ratio: float = 1.0
+    token_density: float = 0.0
+
+    def has_hint(self, hint: str) -> bool:
+        return hint in self.hints
+
+    def token_score(self) -> float:
+        if not self.tokens:
+            return 0.0
+        total = sum(len(token) for token in self.tokens)
+        return total / (len(self.tokens) * 8.0)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "text": self.text,
+            "tokens": list(self.tokens),
+            "classification": self.classification,
+            "confidence": self.confidence,
+            "hints": list(self.hints),
+            "entropy": self.entropy,
+            "case_style": self.case_style,
+            "printable_ratio": self.printable_ratio,
+            "token_density": self.token_density,
+        }
+
+
+class StringClassifier:
+    """Derive human friendly insights about recovered string literals."""
+
+    def __init__(
+        self,
+        *,
+        min_token_length: int = 3,
+        max_tokens: int = 24,
+        stopwords: Sequence[str] = (),
+    ) -> None:
+        self._min_length = min_token_length
+        self._max_tokens = max_tokens
+        self._stopwords = {word.lower() for word in stopwords}
+
+    # ------------------------------------------------------------------
+    def classify(self, text: str) -> StringInsight:
+        tokens = tuple(self._extract_tokens(text))
+        tokens = tokens[: self._max_tokens]
+        classification, confidence, hints, printable_ratio = self._evaluate(text, tokens)
+        entropy = self._character_entropy(text)
+        case_style = self._case_style(text)
+        token_density = self._token_density(text, tokens)
+        return StringInsight(
+            text=text,
+            tokens=tokens,
+            classification=classification,
+            confidence=confidence,
+            hints=hints,
+            entropy=entropy,
+            case_style=case_style,
+            printable_ratio=round(printable_ratio, 3),
+            token_density=token_density,
+        )
+
+    # ------------------------------------------------------------------
+    def _extract_tokens(self, text: str) -> Iterator[str]:
+        for match in _WORD_PATTERN.finditer(text):
+            token = match.group(0)
+            if len(token) < self._min_length:
+                continue
+            lowered = token.lower()
+            if lowered in self._stopwords:
+                continue
+            components = list(self._split_identifier(token))
+            if components:
+                for component in components:
+                    lowered_component = component.lower()
+                    if lowered_component not in self._stopwords:
+                        yield lowered_component
+                continue
+            yield lowered
+
+    def _split_identifier(self, token: str) -> Iterable[str]:
+        if "_" in token and token.upper() != token:
+            pieces = [piece for piece in token.split("_") if len(piece) >= self._min_length]
+            if len(pieces) >= 2:
+                return pieces
+        matches = list(_CAMEL_BOUNDARY.finditer(token))
+        if not matches:
+            return []
+        components: List[str] = []
+        last = 0
+        for match in matches:
+            index = match.start()
+            segment = token[last:index]
+            if len(segment) >= self._min_length:
+                components.append(segment)
+            last = index
+        tail = token[last:]
+        if len(tail) >= self._min_length:
+            components.append(tail)
+        return components
+
+    # ------------------------------------------------------------------
+    def _evaluate(
+        self, text: str, tokens: Sequence[str]
+    ) -> Tuple[str, float, Tuple[str, ...], float]:
+        stripped = text.strip()
+        if not stripped:
+            return "empty", 0.0, ("blank",), 1.0
+        hints: List[str] = []
+        ascii_ratio = self._ascii_ratio(text)
+        if ascii_ratio < 0.6:
+            hints.append("low-printable")
+        if "\n" in text or "\r" in text:
+            hints.append("multiline")
+        if any(ch in text for ch in ("/", "\\")):
+            hints.append("path")
+        if "%" in text:
+            hints.append("format")
+        if "{" in text and "}" in text:
+            hints.append("template")
+        if any(ch.isdigit() for ch in stripped) and not any(ch.isalpha() for ch in stripped):
+            hints.append("numeric")
+        if stripped.endswith("?"):
+            hints.append("question")
+        if stripped.endswith("!"):
+            hints.append("exclamation")
+        classification = self._select_classification(stripped, tokens, hints, ascii_ratio)
+        confidence = self._estimate_confidence(classification, hints, tokens)
+        return classification, confidence, tuple(hints), ascii_ratio
+
+    def _select_classification(
+        self,
+        text: str,
+        tokens: Sequence[str],
+        hints: Sequence[str],
+        ascii_ratio: float,
+    ) -> str:
+        if "low-printable" in hints:
+            return "binary"
+        if "path" in hints:
+            return "path"
+        if "format" in hints or "template" in hints:
+            return "format"
+        if "numeric" in hints:
+            return "numeric"
+        if tokens and self._looks_like_identifier(text, tokens):
+            return "identifier"
+        if tokens and ("?" in hints or "exclamation" in hints):
+            return "dialogue"
+        if tokens and (" " in text or "multiline" in hints):
+            return "sentence"
+        if ascii_ratio > 0.95 and tokens:
+            return "keyword"
+        return "unknown"
+
+    def _estimate_confidence(
+        self,
+        classification: str,
+        hints: Sequence[str],
+        tokens: Sequence[str],
+    ) -> float:
+        base = {
+            "binary": 0.95,
+            "path": 0.9,
+            "format": 0.85,
+            "numeric": 0.75,
+            "identifier": 0.8,
+            "dialogue": 0.6,
+            "sentence": 0.7,
+            "keyword": 0.5,
+            "unknown": 0.4,
+            "empty": 0.0,
+        }[classification]
+        modifier = 0.0
+        if "question" in hints or "exclamation" in hints:
+            modifier += 0.05
+        if tokens:
+            diversity = len({token for token in tokens})
+            modifier += min(0.15, diversity / 40.0)
+        modifier = min(modifier, 0.2)
+        return round(base + modifier, 3)
+
+    def _looks_like_identifier(self, text: str, tokens: Sequence[str]) -> bool:
+        if len(tokens) == 1:
+            token = tokens[0]
+            if token.islower() and " " not in text:
+                return True
+            if token.isupper() and " " not in text:
+                return True
+        if " " in text or "-" in text:
+            return False
+        has_alpha = any(token.isalpha() for token in tokens)
+        return has_alpha and len(tokens) <= 3
+
+    def _ascii_ratio(self, text: str) -> float:
+        if not text:
+            return 1.0
+        printable = sum(1 for char in text if char in _PRINTABLE)
+        return printable / len(text)
+
+    def _character_entropy(self, text: str) -> float:
+        if not text:
+            return 0.0
+        counts = {}
+        for char in text:
+            counts[char] = counts.get(char, 0) + 1
+        total = len(text)
+        entropy = 0.0
+        for count in counts.values():
+            probability = count / total
+            entropy -= probability * math.log2(probability)
+        return round(entropy, 3)
+
+    def _case_style(self, text: str) -> str:
+        letters = [char for char in text if char.isalpha()]
+        if not letters:
+            return "neutral"
+        if all(char.isupper() for char in letters):
+            return "upper"
+        if all(char.islower() for char in letters):
+            return "lower"
+        if letters[0].isupper() and all(char.islower() for char in letters[1:]):
+            return "title"
+        return "mixed"
+
+    def _token_density(self, text: str, tokens: Sequence[str]) -> float:
+        if not text:
+            return 0.0
+        density = len(tokens) / len(text)
+        return round(density, 3)
+
+
+def summarise_insights(insights: Sequence[StringInsight]) -> Tuple[int, List[Tuple[str, int]]]:
+    """Compute a histogram of classifications for collected insights."""
+
+    histogram = {}
+    for insight in insights:
+        key = insight.classification
+        histogram[key] = histogram.get(key, 0) + 1
+    ordered = sorted(histogram.items(), key=lambda item: (-item[1], item[0]))
+    return sum(histogram.values()), ordered
+
+
+def token_histogram(
+    insights: Sequence[StringInsight], limit: int = 10
+) -> List[Tuple[str, int]]:
+    counter: Counter[str] = Counter()
+    for insight in insights:
+        counter.update(insight.tokens)
+    return counter.most_common(limit)
+

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -5,6 +5,7 @@ from mbcdisasm.highlevel import HighLevelReconstructor
 from mbcdisasm.ir import IRBlock, IRInstruction, IRProgram
 from mbcdisasm.knowledge import KnowledgeBase
 from mbcdisasm.manual_semantics import ManualSemanticAnalyzer
+from mbcdisasm.lua_formatter import LuaRenderOptions
 from mbcdisasm.vm_analysis import estimate_stack_io
 
 
@@ -52,6 +53,21 @@ def _extend_with_string(
         instructions.append(_make_instruction(analyzer, offset, "01:00", chunk, None))
         offset += 4
     return offset
+
+
+def _build_program(
+    analyzer: ManualSemanticAnalyzer,
+    texts: list[str],
+    *,
+    segment: int,
+) -> IRProgram:
+    instructions: list[IRInstruction] = []
+    offset = 0
+    for text in texts:
+        offset = _extend_with_string(analyzer, instructions, offset, text)
+    instructions.append(_make_instruction(analyzer, offset, "02:00", 0, "return"))
+    block = IRBlock(start=0x0000, instructions=instructions, successors=[])
+    return IRProgram(segment_index=segment, blocks={block.start: block})
 
 
 def test_highlevel_reconstruction_generates_control_flow(tmp_path: Path) -> None:
@@ -176,9 +192,22 @@ def test_string_literal_sequences_annotated(tmp_path: Path) -> None:
     function = reconstructor.from_ir(program)
     rendered = reconstructor.render([function])
 
-    assert 'string literal sequence: "Hello"' in rendered
+    assert 'string literal sequence: "Hello" (len=5) (name=hello; locals=hello_0, hello_1, hello_2; type=identifier; tokens=[hello]; entropy=' in rendered
+    assert 'case=title' in rendered
+    assert 'density=0.200' in rendered
     assert "-- string literal sequences:" in rendered
-    assert '-- - 0x000000 len=5 chunks=3: "Hello"' in rendered
+    assert '-- - 0x000000 len=5 chunks=3: "Hello" (name=hello, symbols=[hello_0, hello_1, hello_2], type=identifier, tokens=[hello], entropy=' in rendered
+    assert 'case=title' in rendered
+    assert 'density=0.200' in rendered
+    assert "-- string classification summary:" in rendered
+    assert "-- - identifier: 1" in rendered
+    assert "local hello_0 =" in rendered
+    assert "local hello_1 =" in rendered
+    assert "local hello_2 =" in rendered
+    assert "return hello_0, hello_1, hello_2" in rendered
+    assert "string categories: identifier=1" in rendered
+    assert "-- string catalog:" in rendered
+    assert "-- - hello: len=5 chunks=3 type=identifier" in rendered
 
 
 def test_string_sequences_drive_function_naming(tmp_path: Path) -> None:
@@ -235,3 +264,269 @@ def test_string_sequences_drive_function_naming(tmp_path: Path) -> None:
     assert function.name == "set_name"
     assert "function set_name()" in rendered
     assert "-- string literal sequences:" in rendered
+
+
+def test_string_sequences_rename_call_results(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    base_text = "SetNameAction"
+    chunk_count = len(_string_chunks(base_text))
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "Push literal chunk",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "02:00": {
+                    "name": "return_top",
+                    "summary": "Return top value",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+                "03:00": {
+                    "name": "combine_name_chunks",
+                    "summary": "Combine previously pushed name chunks",
+                    "stack_delta": 0,
+                    "tags": ["call"],
+                    "stack_inputs": chunk_count,
+                    "stack_outputs": 1,
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+
+    instructions: list[IRInstruction] = []
+    offset = 0x0000
+    offset = _extend_with_string(analyzer, instructions, offset, base_text)
+    call_offset = offset
+    instructions.append(_make_instruction(analyzer, call_offset, "03:00", 0, None))
+    return_offset = call_offset + 4
+    instructions.append(_make_instruction(analyzer, return_offset, "02:00", 0, "return"))
+
+    block = IRBlock(start=0x0000, instructions=instructions, successors=[])
+    program = IRProgram(segment_index=5, blocks={block.start: block})
+
+    reconstructor = HighLevelReconstructor(knowledge)
+    function = reconstructor.from_ir(program)
+    rendered = reconstructor.render([function])
+
+    assert "local set_name_action_value =" in rendered
+    consumer_hint = f"combine_name_chunks@0x{call_offset:06X}"
+    assert consumer_hint in rendered
+    assert f"used_by=[{consumer_hint}]" in rendered
+
+
+def test_string_literals_generate_snake_case_locals(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "Push literal chunk",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "02:00": {
+                    "name": "return_top",
+                    "summary": "Return top value",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+
+    instructions: list[IRInstruction] = []
+    offset = 0x0000
+    offset = _extend_with_string(analyzer, instructions, offset, "SetPlayerName")
+    instructions.append(_make_instruction(analyzer, offset, "02:00", 0, "return"))
+    block = IRBlock(start=0x0000, instructions=instructions, successors=[])
+    program = IRProgram(segment_index=0, blocks={block.start: block})
+
+    reconstructor = HighLevelReconstructor(knowledge)
+    function = reconstructor.from_ir(program)
+    rendered = reconstructor.render([function])
+
+    assert "local set_player_name_0 =" in rendered
+    assert 'string literal sequence: "SetPlayerName" (len=13) (name=set_player_name; locals=set_player_name_0, set_player_name_1, set_player_name_2, set_player_name_3, set_player_name_4, set_player_name_5, set_player_name_6; type=identifier; tokens=[set, player, name]; entropy=' in rendered
+    assert 'case=mixed' in rendered
+    assert "-- - set_player_name: len=13 chunks=7 type=identifier" in rendered
+    assert "return set_player_name_0, set_player_name_1, set_player_name_2" in rendered
+
+
+def test_disable_string_catalog_option(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "Push literal chunk",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "02:00": {
+                    "name": "return_top",
+                    "summary": "Return top value",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+
+    instructions: list[IRInstruction] = []
+    offset = 0x0000
+    offset = _extend_with_string(analyzer, instructions, offset, "CatalogTest")
+    instructions.append(_make_instruction(analyzer, offset, "02:00", 0, "return"))
+    block = IRBlock(start=0x0000, instructions=instructions, successors=[])
+    program = IRProgram(segment_index=0, blocks={block.start: block})
+
+    options = LuaRenderOptions(emit_string_catalog=False)
+    reconstructor = HighLevelReconstructor(knowledge, options=options)
+    function = reconstructor.from_ir(program)
+    rendered = reconstructor.render([function])
+
+    assert "string literal sequences:" in rendered
+    assert "-- string catalog:" not in rendered
+
+
+def test_string_catalog_groups_sequences(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "Push literal chunk",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "02:00": {
+                    "name": "return_top",
+                    "summary": "Return top value",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+
+    program_a = _build_program(analyzer, ["AlphaBeta"], segment=1)
+    program_b = _build_program(analyzer, ["system/path/config"], segment=2)
+
+    reconstructor = HighLevelReconstructor(knowledge)
+    function_a = reconstructor.from_ir(program_a)
+    function_b = reconstructor.from_ir(program_b)
+    rendered = reconstructor.render([function_a, function_b])
+
+    assert "-- string catalog:" in rendered
+    assert "-- - alpha_beta" in rendered
+    assert "type=identifier" in rendered
+    assert "-- - system:" in rendered
+    assert "type=path" in rendered
+    assert "tokens=[system, path, config]" in rendered
+
+
+def test_string_insight_report_json_serialisation(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "Push literal chunk",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "02:00": {
+                    "name": "return_top",
+                    "summary": "Return top value",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+    program = _build_program(analyzer, ["Alpha", "Beta"], segment=3)
+    reconstructor = HighLevelReconstructor(knowledge)
+    function = reconstructor.from_ir(program)
+    report = reconstructor.string_insight_report([function])
+
+    output = tmp_path / "insights.json"
+    output.write_text(json.dumps(report, indent=2), "utf-8")
+    loaded = json.loads(output.read_text("utf-8"))
+    assert loaded["entry_count"] == 1
+    assert loaded["summary"]["total_sequences"] == 1
+
+
+def test_string_insight_report_structure(tmp_path: Path) -> None:
+    kb_path = tmp_path / "kb.json"
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "01:00": {
+                    "name": "push_literal_small",
+                    "summary": "Push literal chunk",
+                    "stack_delta": 1,
+                    "tags": ["literal"],
+                },
+                "02:00": {
+                    "name": "return_top",
+                    "summary": "Return top value",
+                    "stack_delta": -1,
+                    "control_flow": "return",
+                },
+            }
+        ),
+        "utf-8",
+    )
+
+    knowledge = KnowledgeBase.load(kb_path)
+    analyzer = ManualSemanticAnalyzer(knowledge)
+    program = _build_program(analyzer, ["AlphaBeta"], segment=0)
+    reconstructor = HighLevelReconstructor(knowledge)
+    function = reconstructor.from_ir(program)
+
+    report = reconstructor.string_insight_report([function])
+    assert report["entry_count"] == 1
+    entry = report["entries"][0]
+    assert report["classifications"][0][0] == "identifier"
+    assert report["summary"]["total_sequences"] == 1
+    assert report["summary"]["average_entropy"] > 0
+    assert report["summary"]["top_tokens"][0][0] == "alpha"
+    assert entry["function"] == function.name
+    assert entry["classification"] == "identifier"
+    assert entry["case_style"] == "mixed"
+    assert entry["token_density"] > 0
+    assert entry["text"].startswith("Alpha")
+    assert entry["consumers"] == []

--- a/tests/test_string_analysis.py
+++ b/tests/test_string_analysis.py
@@ -1,0 +1,65 @@
+from mbcdisasm.string_analysis import (
+    StringClassifier,
+    summarise_insights,
+    token_histogram,
+)
+
+
+def test_classifier_identifies_camel_case_identifier() -> None:
+    classifier = StringClassifier()
+    insight = classifier.classify("SetPlayerName")
+    assert insight.classification == "identifier"
+    assert insight.tokens[:3] == ("set", "player", "name")
+    assert insight.confidence >= 0.7
+    assert insight.entropy > 0.0
+    assert insight.case_style == "mixed"
+    data = insight.as_dict()
+    assert data["classification"] == "identifier"
+    assert data["case_style"] == "mixed"
+    assert 0.0 <= data["printable_ratio"] <= 1.0
+    assert data["token_density"] > 0.0
+
+
+def test_classifier_detects_paths_and_formats() -> None:
+    classifier = StringClassifier()
+    path_insight = classifier.classify("/assets/scripts/init.lua")
+    assert path_insight.classification == "path"
+    assert "path" in path_insight.hints
+
+    format_insight = classifier.classify("Hello %s! Score: %d")
+    assert format_insight.classification == "format"
+    assert "format" in format_insight.hints
+
+
+def test_classifier_low_printable_detection() -> None:
+    classifier = StringClassifier()
+    noisy_text = "Hello\x01World"
+    insight = classifier.classify(noisy_text)
+    assert insight.printable_ratio < 1.0
+    assert insight.entropy > 0.0
+
+
+def test_token_histogram_counts_tokens() -> None:
+    classifier = StringClassifier()
+    insights = [
+        classifier.classify("AlphaBeta"),
+        classifier.classify("AlphaGamma"),
+        classifier.classify("Beta"),
+    ]
+    histogram = token_histogram(insights, limit=3)
+    assert histogram[0][0] == "alpha"
+    assert histogram[0][1] == 2
+    assert any(token == "beta" for token, _ in histogram)
+
+
+def test_summarise_insights_orders_histogram() -> None:
+    classifier = StringClassifier()
+    insights = [
+        classifier.classify("Quest complete"),
+        classifier.classify("/tmp/output.txt"),
+        classifier.classify("PlayerName"),
+        classifier.classify("Do you accept the quest?")
+    ]
+    total, histogram = summarise_insights(insights)
+    assert total == 4
+    assert histogram[0][0] in {"identifier", "path", "sentence", "dialogue", "unknown"}


### PR DESCRIPTION
## Summary
- enhance `StringLiteralSequence` metadata with consumer tracking, refreshed comments, and stack registration to drive naming
- update call translation logic to detect trailing string sequences, rename helper results, and record consumers in summaries and catalog output
- extend the string insight report and catalog to expose consumer usage and add coverage for the new heuristics in unit tests

## Testing
- pytest tests/test_highlevel.py tests/test_string_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68dab51a4188832f914761d45fb8000e