### PR TITLE
Add structural pipeline analyzer for stack-based Lua VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository now focuses on a single task: producing annotated disassembly listings for Sphere `.mbc` script containers.  The command-line interface reads a container plus its `.adb` index file and emits a plain text listing with mnemonics and stack hints sourced from `knowledge/manual_annotations.json`.
 
+The scripts packed into `.mbc` archives are compiled from an early 2000s
+Lua-inspired language.  They target a strictly stack based virtual machine that
+uses big-endian 32-bit instruction words composed of two 16-bit halves.  Most
+opcodes follow rigid stack discipline: literal loaders and inline ASCII chunk
+assemblers increase the height by one, reducers collapse multiple values into a
+single result, while control flow instructions preserve or deliberately tear
+down the frame.  These invariants form the basis for the pipeline analyser
+described below.
+
 ## Usage
 
 ```
@@ -16,6 +25,18 @@ The tool loads opcode metadata from `knowledge/opcode_profiles.json`.  Manual ov
 - `--knowledge-base` points to an alternate knowledge database location.
 
 The CLI prints the final output path and writes the listing to disk.
+
+## Pipeline analyser
+
+The `mbcdisasm.analyzer` package introduces a structural analysis pass on top of
+the plain disassembly.  It scans for stable conveyor forms that repeat all over
+Lua-style bytecode: literal → push → test sequences, inline ASCII chunk loading
+and reduction, call frame preparation, indirect table lookups and the various
+return/terminator combinations.  The analyser combines deterministic stack
+tracking with small local opcode templates and the surrounding control-flow
+context.  Each recognised pipeline block records its stack delta, dominant
+instruction kind and confidence score, providing a solid foundation for higher
+level decompilation or refactoring tools.
 
 ## Tests
 

--- a/mbcdisasm/analyzer/__init__.py
+++ b/mbcdisasm/analyzer/__init__.py
@@ -1,0 +1,47 @@
+"""High level pipeline analysis toolkit.
+
+The :mod:`mbcdisasm.analyzer` package provides the infrastructure required to
+convert a raw instruction stream into an annotated collection of *pipeline
+blocks*.  A pipeline block is a short sequence of instructions – typically
+between two and six words – that together implement a well defined operation in
+Sphere's Lua-inspired virtual machine.  Historically the project offered only a
+single-pass disassembler that printed annotated mnemonics.  While helpful for
+manual inspection, the output did not expose the higher level structure needed
+for automated rewriting or decompilation.  The new analyzer closes that gap by
+extracting common execution forms such as literal loaders, push chains, tail
+call preparation and control flow tests.
+
+The package is intentionally opinionated: it encodes the heuristics that were
+observed in multiple megabytes of real `.mbc` bytecode and combines them with a
+stack-aware scoring system.  The resulting analysis is deterministic and does
+not rely on speculative execution.  Users can feed the pipeline analyser with
+instruction words produced by :func:`mbcdisasm.instruction.read_instructions`
+and will receive structured blocks that are ready for higher level translation.
+
+The public surface of the module is intentionally small and revolves around the
+:class:`~mbcdisasm.analyzer.pipeline.PipelineAnalyzer` class.  A typical workflow
+looks as follows::
+
+    from mbcdisasm import KnowledgeBase
+    from mbcdisasm.analyzer import PipelineAnalyzer
+    from mbcdisasm.instruction import read_instructions
+
+    instructions, _ = read_instructions(segment_bytes, base_offset)
+    knowledge = KnowledgeBase.load(manual_annotations_path)
+    analyzer = PipelineAnalyzer(knowledge)
+    report = analyzer.analyse_segment(instructions)
+
+    for block in report.blocks:
+        print(block.describe())
+
+The :class:`~mbcdisasm.analyzer.report.PipelineReport` returned by the analyser
+contains a curated view of the segment.  Each block records its stack delta,
+confidence, dominant instruction kinds and context.  Consumers may use this
+information to build higher level control flow graphs or to detect suspicious
+patterns that need manual review.
+"""
+
+from .pipeline import PipelineAnalyzer
+from .report import PipelineBlock, PipelineReport
+
+__all__ = ["PipelineAnalyzer", "PipelineBlock", "PipelineReport"]

--- a/mbcdisasm/analyzer/context.py
+++ b/mbcdisasm/analyzer/context.py
@@ -1,0 +1,117 @@
+"""Context building utilities for the pipeline analyser."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+from .instruction_profile import InstructionProfile
+from .stack import StackSummary, StackTracker
+
+
+@dataclass(frozen=True)
+class InstructionWindow:
+    """A contiguous window of instruction profiles."""
+
+    profiles: Tuple[InstructionProfile, ...]
+
+    @property
+    def start_offset(self) -> int:
+        return self.profiles[0].word.offset if self.profiles else 0
+
+    @property
+    def end_offset(self) -> int:
+        return self.profiles[-1].word.offset if self.profiles else 0
+
+    def stack_summary(self) -> StackSummary:
+        tracker = StackTracker()
+        return tracker.run(self.profiles)
+
+    def __iter__(self) -> Iterator[InstructionProfile]:
+        return iter(self.profiles)
+
+    def __len__(self) -> int:
+        return len(self.profiles)
+
+
+@dataclass
+class ControlBoundary:
+    """Represents a control flow boundary in the instruction stream."""
+
+    ordinal: int
+    position: int
+    profile: InstructionProfile
+
+    def describe(self) -> str:
+        return f"boundary#{self.ordinal} {self.profile.describe()}"
+
+
+@dataclass
+class LinearBlock:
+    """A linear region between two control flow boundaries."""
+
+    start: ControlBoundary
+    end: ControlBoundary
+    window: InstructionWindow
+    stack_summary: StackSummary
+
+    def describe(self) -> str:
+        return (
+            f"block {self.start.ordinal}->{self.end.ordinal} "
+            f"[{self.window.start_offset:08X}-{self.window.end_offset:08X}] "
+            f"{self.stack_summary.describe()}"
+        )
+
+    def profiles(self) -> Tuple[InstructionProfile, ...]:
+        return self.window.profiles
+
+
+class SegmentContext:
+    """Builds :class:`LinearBlock` objects from instruction profiles."""
+
+    def __init__(self, profiles: Sequence[InstructionProfile]) -> None:
+        self.profiles = tuple(profiles)
+        self.boundaries: List[ControlBoundary] = []
+        self.blocks: List[LinearBlock] = []
+        self._build()
+
+    def _build(self) -> None:
+        boundary_indices = [idx for idx, profile in enumerate(self.profiles) if profile.is_control()]
+        if not boundary_indices:
+            return
+
+        self.boundaries = [
+            ControlBoundary(ordinal=i, position=idx, profile=self.profiles[idx])
+            for i, idx in enumerate(boundary_indices)
+        ]
+
+        for left, right in zip(self.boundaries, self.boundaries[1:]):
+            window = InstructionWindow(self.profiles[left.position + 1 : right.position])
+            summary = window.stack_summary()
+            self.blocks.append(LinearBlock(start=left, end=right, window=window, stack_summary=summary))
+
+    def iter_blocks(self) -> Iterable[LinearBlock]:
+        return iter(self.blocks)
+
+    def summary(self) -> "ContextSummary":
+        lengths = [len(block.window.profiles) for block in self.blocks]
+        if not lengths:
+            return ContextSummary(block_count=0, average_length=0.0, max_length=0)
+        average = sum(lengths) / len(lengths)
+        maximum = max(lengths)
+        return ContextSummary(block_count=len(lengths), average_length=average, max_length=maximum)
+
+
+@dataclass
+class ContextSummary:
+    """Small utility structure summarising a segment."""
+
+    block_count: int
+    average_length: float
+    max_length: int
+
+    def describe(self) -> str:
+        return f"blocks={self.block_count} avg={self.average_length:.2f} max={self.max_length}"
+
+    def is_empty(self) -> bool:
+        return self.block_count == 0

--- a/mbcdisasm/analyzer/dfa.py
+++ b/mbcdisasm/analyzer/dfa.py
@@ -1,0 +1,153 @@
+"""Deterministic finite automata support for pipeline pattern matching."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple
+
+from .patterns import PatternRegistry, PipelinePattern, PatternMatch
+from .stack import StackEvent
+
+
+@dataclass
+class Transition:
+    """Represents an automaton transition."""
+
+    target: int
+    token_index: int
+
+
+@dataclass
+class AutomatonState:
+    """A single DFA state."""
+
+    index: int
+    transitions: Dict[int, Transition] = field(default_factory=dict)
+    accepting: List[int] = field(default_factory=list)
+
+    def add_transition(self, symbol: int, transition: Transition) -> None:
+        self.transitions[symbol] = transition
+
+
+@dataclass
+class AutomatonMatch:
+    """Match result produced by the DFA."""
+
+    pattern_index: int
+    start: int
+    end: int
+    score: float
+
+
+@dataclass
+class AutomatonTrace:
+    """Trace produced while the DFA walks through a sequence."""
+
+    start: int
+    end: int
+    states: Tuple[int, ...]
+    matches: Tuple[AutomatonMatch, ...]
+
+    def describe(self) -> str:
+        path = "->".join(str(state) for state in self.states)
+        return f"trace[{self.start}:{self.end}] path={path} matches={len(self.matches)}"
+
+
+class DeterministicAutomaton:
+    """Simple DFA for scanning instruction streams."""
+
+    def __init__(self, registry: PatternRegistry) -> None:
+        self.registry = registry
+        self.patterns: Tuple[PipelinePattern, ...] = tuple(registry)
+        self.states: List[AutomatonState] = []
+        self._build_states()
+
+    def _build_states(self) -> None:
+        self.states = [AutomatonState(index=0)]
+        for idx, pattern in enumerate(self.patterns):
+            self._insert_pattern(idx, pattern)
+
+    def _insert_pattern(self, index: int, pattern: PipelinePattern) -> None:
+        state = self.states[0]
+        for token_idx, _token in enumerate(pattern.tokens):
+            key = self._transition_key(index, token_idx)
+            if key not in state.transitions:
+                next_state = AutomatonState(index=len(self.states))
+                self.states.append(next_state)
+                state.add_transition(key, Transition(target=next_state.index, token_index=token_idx))
+            transition = state.transitions[key]
+            state = self.states[transition.target]
+        state.accepting.append(index)
+
+    def _transition_key(self, pattern_index: int, token_index: int) -> int:
+        return (pattern_index << 8) | token_index
+
+    # ------------------------------------------------------------------
+    # high level APIs
+    # ------------------------------------------------------------------
+    def iter_matches(self, events: Sequence[StackEvent]) -> Iterator[AutomatonMatch]:
+        """Yield all matches found in ``events``."""
+
+        for start in range(len(events)):
+            for pattern_index, pattern in enumerate(self.patterns):
+                end = start + len(pattern.tokens)
+                if end > len(events):
+                    continue
+                slice_events = events[start:end]
+                match = pattern.match(slice_events)
+                if match is None:
+                    continue
+                if not pattern.allow_extra and len(slice_events) != len(pattern.tokens):
+                    yield AutomatonMatch(pattern_index=pattern_index, start=start, end=end, score=match.score)
+                else:
+                    # allow extra instructions until a control boundary is hit
+                    extra_end = end
+                    while extra_end < len(events):
+                        extended = events[start:extra_end + 1]
+                        extended_match = pattern.match(extended)
+                        if extended_match is None:
+                            break
+                        extra_end += 1
+                        match = extended_match
+                    yield AutomatonMatch(pattern_index=pattern_index, start=start, end=extra_end, score=match.score)
+
+    def best_match(self, events: Sequence[StackEvent]) -> Optional[PatternMatch]:
+        """Return the best scoring :class:`PatternMatch` for ``events``."""
+
+        best: Optional[PatternMatch] = None
+        for pattern in self.patterns:
+            match = pattern.match(events)
+            if match is None:
+                continue
+            if best is None or match.score > best.score:
+                best = match
+        return best
+
+    def scan(self, events: Sequence[StackEvent], *, window: Optional[int] = None) -> Tuple[AutomatonMatch, ...]:
+        """Return all matches found in ``events`` within ``window`` steps."""
+
+        matches: List[AutomatonMatch] = []
+        limit = window or len(events)
+        for start in range(len(events)):
+            if start >= limit:
+                break
+            for match in self.iter_matches(events[start: start + limit]):
+                matches.append(
+                    AutomatonMatch(
+                        pattern_index=match.pattern_index,
+                        start=start + match.start,
+                        end=start + match.end,
+                        score=match.score,
+                    )
+                )
+        return tuple(matches)
+
+    def trace(self, events: Sequence[StackEvent]) -> AutomatonTrace:
+        """Produce a trace that records state transitions for ``events``."""
+
+        states = [0]
+        matches: List[AutomatonMatch] = []
+        for match in self.iter_matches(events):
+            matches.append(match)
+            states.append(match.end)
+        return AutomatonTrace(start=0, end=len(events), states=tuple(states), matches=tuple(matches))

--- a/mbcdisasm/analyzer/diagnostics.py
+++ b/mbcdisasm/analyzer/diagnostics.py
@@ -1,0 +1,121 @@
+"""Diagnostic helpers for pipeline analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from .report import PipelineBlock
+
+
+@dataclass
+class DiagnosticEntry:
+    """Single diagnostic item."""
+
+    severity: str
+    message: str
+    block: PipelineBlock
+    hints: Tuple[str, ...] = tuple()
+
+    def describe(self) -> str:
+        prefix = {"info": "ℹ", "warning": "⚠", "error": "✖"}.get(self.severity, "•")
+        return f"{prefix} 0x{self.block.start_offset:08X}: {self.message}"
+
+
+@dataclass
+class DiagnosticSummary:
+    """Aggregate view of diagnostic severities."""
+
+    info: int = 0
+    warning: int = 0
+    error: int = 0
+
+    def register(self, severity: str) -> None:
+        if severity == "info":
+            self.info += 1
+        elif severity == "warning":
+            self.warning += 1
+        elif severity == "error":
+            self.error += 1
+
+    def describe(self) -> str:
+        return f"info={self.info} warning={self.warning} error={self.error}"
+
+
+@dataclass
+class DiagnosticReport:
+    """Collection of diagnostic entries."""
+
+    entries: Tuple[DiagnosticEntry, ...]
+    summary: DiagnosticSummary
+
+    def filter(self, severity: str) -> Tuple[DiagnosticEntry, ...]:
+        return tuple(entry for entry in self.entries if entry.severity == severity)
+
+    def describe(self) -> str:
+        lines = ["Diagnostics:", "  summary=" + self.summary.describe()]
+        for entry in self.entries:
+            lines.append("  " + entry.describe())
+        return "\n".join(lines)
+
+
+@dataclass
+class DiagnosticSettings:
+    """Parameters steering diagnostic generation."""
+
+    low_confidence_threshold: float = 0.35
+    stack_spread_threshold: int = 4
+    literal_mismatch_threshold: float = -0.05
+    max_entries: int = 64
+
+
+class DiagnosticBuilder:
+    """Produce diagnostics from analysed pipeline blocks."""
+
+    def __init__(self, settings: Optional[DiagnosticSettings] = None) -> None:
+        self.settings = settings or DiagnosticSettings()
+
+    def evaluate(self, blocks: Sequence[PipelineBlock]) -> DiagnosticReport:
+        entries: List[DiagnosticEntry] = []
+        summary = DiagnosticSummary()
+        for block in blocks:
+            block_entries = self._evaluate_block(block)
+            entries.extend(block_entries)
+            for entry in block_entries:
+                summary.register(entry.severity)
+            if len(entries) >= self.settings.max_entries:
+                break
+        return DiagnosticReport(entries=tuple(entries), summary=summary)
+
+    def _evaluate_block(self, block: PipelineBlock) -> List[DiagnosticEntry]:
+        entries: List[DiagnosticEntry] = []
+        if block.confidence < self.settings.low_confidence_threshold:
+            entries.append(
+                DiagnosticEntry(
+                    severity="warning",
+                    message=f"low confidence classification ({block.confidence:.2f})",
+                    block=block,
+                    hints=tuple(block.notes),
+                )
+            )
+        spread = block.stack.maximum - block.stack.minimum
+        if spread >= self.settings.stack_spread_threshold:
+            entries.append(
+                DiagnosticEntry(
+                    severity="info",
+                    message=f"wide stack range ({spread})",
+                    block=block,
+                    hints=tuple(block.notes),
+                )
+            )
+        for note in block.notes:
+            if "literal" in note and "reduced" in note:
+                entries.append(
+                    DiagnosticEntry(
+                        severity="info",
+                        message="literal block reduced stack",
+                        block=block,
+                        hints=(note,),
+                    )
+                )
+        return entries

--- a/mbcdisasm/analyzer/heuristics.py
+++ b/mbcdisasm/analyzer/heuristics.py
@@ -1,0 +1,248 @@
+"""Auxiliary heuristics used to refine pipeline classification.
+
+The heuristics implemented here mirror the multi-layered approach described in
+the project notes:
+
+1.  Strict stack invariants – every block is evaluated with a running stack
+    counter that exposes the cumulative delta and the minimum depth touched by
+    the instructions.
+2.  Local opcode templates – lightweight pattern detectors that flag literal
+    trains, inline ASCII chunk reducers and call frame initialisers.
+3.  Control context – ties the block to the surrounding control flow
+    instructions and provides hints on whether we are looking at operand
+    preparation, indirect loads or teardown sequences.
+4.  Indirect detection – identifies table lookups and other two-stage operand
+    fetches by examining opcode combinations and stack deltas.
+5.  Gap analysis – computes how much of the linear instruction stream is covered
+    by recognised pipelines and tags suspicious leftovers for manual review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping, Optional, Sequence, Tuple
+
+from .instruction_profile import InstructionKind, InstructionProfile, filter_profiles
+from .stack import StackSummary
+
+
+@dataclass(frozen=True)
+class LocalFeature:
+    """Single heuristic feature produced during analysis."""
+
+    name: str
+    score: float
+    evidence: Tuple[str, ...] = tuple()
+
+    def describe(self) -> str:
+        parts = [f"{self.name}={self.score:.2f}"]
+        if self.evidence:
+            parts.append("(" + ", ".join(self.evidence) + ")")
+        return " ".join(parts)
+
+
+@dataclass(frozen=True)
+class HeuristicReport:
+    """Collection of heuristic features."""
+
+    features: Tuple[LocalFeature, ...]
+    stack_delta: int
+    stack_range: Tuple[int, int]
+    confidence: float
+
+    def feature_map(self) -> Mapping[str, LocalFeature]:
+        return {feature.name: feature for feature in self.features}
+
+    def describe(self) -> str:
+        chunks = [feature.describe() for feature in self.features]
+        chunks.append(f"stackΔ={self.stack_delta:+d}")
+        chunks.append(f"range=({self.stack_range[0]:+d},{self.stack_range[1]:+d})")
+        chunks.append(f"conf={self.confidence:.2f}")
+        return " ".join(chunks)
+
+
+@dataclass
+class HeuristicSettings:
+    """Configuration options for the heuristic engine."""
+
+    literal_weight: float = 0.2
+    push_weight: float = 0.15
+    test_weight: float = 0.1
+    call_weight: float = 0.3
+    return_weight: float = 0.25
+    indirect_weight: float = 0.2
+    max_literal_gap: int = 2
+    max_call_gap: int = 3
+
+
+class HeuristicEngine:
+    """Generate heuristic reports for instruction blocks."""
+
+    def __init__(self, settings: Optional[HeuristicSettings] = None) -> None:
+        self.settings = settings or HeuristicSettings()
+
+    def analyse(
+        self,
+        profiles: Sequence[InstructionProfile],
+        stack: StackSummary,
+        *,
+        previous: Optional[InstructionProfile] = None,
+        following: Optional[InstructionProfile] = None,
+    ) -> HeuristicReport:
+        features: List[LocalFeature] = []
+
+        features.extend(self._stack_features(stack))
+        features.extend(self._literal_features(profiles))
+        features.extend(self._call_features(profiles, following))
+        features.extend(self._return_features(profiles, following))
+        features.extend(self._indirect_features(profiles))
+        features.extend(self._context_features(previous, following))
+
+        confidence = sum(feature.score for feature in features)
+        confidence = max(0.0, min(1.0, confidence))
+
+        return HeuristicReport(
+            features=tuple(features),
+            stack_delta=stack.change,
+            stack_range=(stack.minimum, stack.maximum),
+            confidence=confidence,
+        )
+
+    # ------------------------------------------------------------------
+    # individual feature extractors
+    # ------------------------------------------------------------------
+    def _stack_features(self, stack: StackSummary) -> List[LocalFeature]:
+        features: List[LocalFeature] = []
+        features.append(LocalFeature(name="stack_delta", score=self._score_stack_delta(stack)))
+        if stack.uncertain:
+            features.append(LocalFeature(name="stack_uncertain", score=-0.2))
+        spread = stack.maximum - stack.minimum
+        if spread <= 1:
+            features.append(LocalFeature(name="stack_stable", score=0.1, evidence=("spread<=1",)))
+        else:
+            features.append(LocalFeature(name="stack_spread", score=-0.05, evidence=(f"spread={spread}",)))
+        return features
+
+    def _score_stack_delta(self, stack: StackSummary) -> float:
+        if stack.change == 0:
+            return 0.05
+        if stack.change > 0:
+            return 0.1
+        return 0.0
+
+    def _literal_features(self, profiles: Sequence[InstructionProfile]) -> List[LocalFeature]:
+        literal_like = filter_profiles(
+            profiles,
+            {
+                InstructionKind.LITERAL,
+                InstructionKind.ASCII_CHUNK,
+                InstructionKind.PUSH,
+                InstructionKind.TABLE_LOOKUP,
+            },
+        )
+        features: List[LocalFeature] = []
+        if literal_like:
+            weight = self.settings.literal_weight * len(literal_like)
+            evidence = tuple(profile.label for profile in literal_like[:3])
+            features.append(LocalFeature(name="literal_chain", score=weight, evidence=evidence))
+        gaps = self._literal_gaps(profiles)
+        if gaps:
+            for gap in gaps:
+                features.append(LocalFeature(name="literal_gap", score=-0.05, evidence=(str(gap),)))
+        return features
+
+    def _literal_gaps(self, profiles: Sequence[InstructionProfile]) -> List[int]:
+        gaps: List[int] = []
+        run = 0
+        for profile in profiles:
+            if profile.kind in {InstructionKind.LITERAL, InstructionKind.ASCII_CHUNK, InstructionKind.PUSH}:
+                run += 1
+                continue
+            if run:
+                if run <= self.settings.max_literal_gap:
+                    gaps.append(run)
+                run = 0
+        if run and run <= self.settings.max_literal_gap:
+            gaps.append(run)
+        return gaps
+
+    def _call_features(
+        self,
+        profiles: Sequence[InstructionProfile],
+        following: Optional[InstructionProfile],
+    ) -> List[LocalFeature]:
+        features: List[LocalFeature] = []
+        call_like = filter_profiles(
+            profiles,
+            {
+                InstructionKind.CALL,
+                InstructionKind.TAILCALL,
+                InstructionKind.META,
+            },
+        )
+        if call_like:
+            evidence = tuple(profile.label for profile in call_like)
+            features.append(
+                LocalFeature(
+                    name="call_helper",
+                    score=self.settings.call_weight * len(call_like),
+                    evidence=evidence,
+                )
+            )
+            if following and following.kind is InstructionKind.BRANCH:
+                features.append(LocalFeature(name="call_followed_by_branch", score=0.05))
+        return features
+
+    def _return_features(
+        self,
+        profiles: Sequence[InstructionProfile],
+        following: Optional[InstructionProfile],
+    ) -> List[LocalFeature]:
+        features: List[LocalFeature] = []
+        teardown = filter_profiles(profiles, {InstructionKind.STACK_TEARDOWN})
+        returns = filter_profiles(profiles, {InstructionKind.RETURN, InstructionKind.TERMINATOR})
+        if teardown:
+            features.append(
+                LocalFeature(
+                    name="stack_teardown",
+                    score=self.settings.return_weight * len(teardown),
+                    evidence=tuple(profile.label for profile in teardown),
+                )
+            )
+        if returns:
+            features.append(
+                LocalFeature(
+                    name="return_sequence",
+                    score=self.settings.return_weight * len(returns),
+                    evidence=tuple(profile.label for profile in returns),
+                )
+            )
+        if following and following.kind is InstructionKind.TERMINATOR:
+            features.append(LocalFeature(name="terminator_followup", score=0.05))
+        return features
+
+    def _indirect_features(self, profiles: Sequence[InstructionProfile]) -> List[LocalFeature]:
+        features: List[LocalFeature] = []
+        base = filter_profiles(profiles, {InstructionKind.PUSH, InstructionKind.LITERAL})
+        lookup = filter_profiles(profiles, {InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP})
+        if base and lookup:
+            features.append(
+                LocalFeature(
+                    name="indirect_pattern",
+                    score=self.settings.indirect_weight,
+                    evidence=(base[0].label, lookup[-1].label),
+                )
+            )
+        return features
+
+    def _context_features(
+        self,
+        previous: Optional[InstructionProfile],
+        following: Optional[InstructionProfile],
+    ) -> List[LocalFeature]:
+        features: List[LocalFeature] = []
+        if previous and previous.is_control():
+            features.append(LocalFeature(name="pre_control", score=0.05, evidence=(previous.label,)))
+        if following and following.is_control():
+            features.append(LocalFeature(name="post_control", score=0.05, evidence=(following.label,)))
+        return features

--- a/mbcdisasm/analyzer/instruction_profile.py
+++ b/mbcdisasm/analyzer/instruction_profile.py
@@ -1,0 +1,377 @@
+"""Instruction profiling helpers.
+
+The :class:`InstructionProfile` class wraps :class:`~mbcdisasm.instruction.InstructionWord`
+instances with metadata derived from the knowledge base and with additional
+heuristic classification.  Pipeline recognition operates on these enriched
+profiles rather than the bare instruction words because the metadata exposes
+events such as *"this instruction consumes the top stack value"* or *"this is a
+terminator"*.  Each profile attempts to normalise the low level signals into a
+small set of categories that can be consumed by finite state matchers or by the
+stack tracker.
+
+The module is intentionally verbose – every helper method is documented and the
+logic is broken into many small units.  This makes the heuristics easy to unit
+ test and provides numerous hooks for future experimentation.  The heavy
+commentary also serves as a form of living documentation for the reversing work
+which has traditionally been scattered across private notes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Iterable, Mapping, Optional, Sequence, Tuple
+
+from ..instruction import InstructionWord
+from ..knowledge import KnowledgeBase, OpcodeInfo
+
+
+class InstructionKind(Enum):
+    """High level classification of an opcode.
+
+    The enumeration is intentionally exhaustive and contains several flavours of
+    stack manipulation instructions.  Lua-style VMs tend to encode literal
+    loaders, stack adjustments and indirect loads via distinct opcodes which are
+    extremely regular across the binary.  Having discrete entries for these
+    groups simplifies the later pattern matching passes.
+    """
+
+    CONTROL = auto()
+    TERMINATOR = auto()
+    BRANCH = auto()
+    CALL = auto()
+    TAILCALL = auto()
+    RETURN = auto()
+    LITERAL = auto()
+    ASCII_CHUNK = auto()
+    PUSH = auto()
+    REDUCE = auto()
+    STACK_TEARDOWN = auto()
+    STACK_COPY = auto()
+    TEST = auto()
+    INDIRECT = auto()
+    TABLE_LOOKUP = auto()
+    ARITHMETIC = auto()
+    LOGICAL = auto()
+    BITWISE = auto()
+    META = auto()
+    UNKNOWN = auto()
+
+
+@dataclass(frozen=True)
+class StackEffectHint:
+    """Represents a stack delta hint used during analysis.
+
+    The hint stores both a nominal delta and a range.  When the manual
+    annotations specify an exact ``stack_delta`` the ``minimum`` and ``maximum``
+    values are equal to that number.  When only pushes or pops are defined the
+    class normalises them into a signed delta.  The pipeline analyser prefers to
+    work with :class:`StackEffectHint` instances instead of raw integers because
+    several opcodes expose mode-dependent behaviour.  In those cases a wide
+    ``minimum``/``maximum`` range is recorded which tells the stack tracker to be
+    conservative.
+    """
+
+    nominal: int
+    minimum: int
+    maximum: int
+    confidence: float = 1.0
+
+    @classmethod
+    def from_info(cls, info: Optional[OpcodeInfo]) -> "StackEffectHint":
+        """Build a hint from :class:`OpcodeInfo` metadata.
+
+        When the manual annotations do not expose any stack information a neutral
+        hint (``nominal == minimum == maximum == 0``) is returned with a low
+        confidence score.  The analyser will treat such instructions as
+        stack-neutral unless additional heuristics override the estimate.
+        """
+
+        if info is None:
+            return cls(nominal=0, minimum=0, maximum=0, confidence=0.25)
+
+        if info.stack_delta is not None:
+            delta = int(info.stack_delta)
+            return cls(nominal=delta, minimum=delta, maximum=delta, confidence=0.95)
+
+        pushed = info.stack_push if info.stack_push is not None else 0
+        popped = info.stack_pop if info.stack_pop is not None else 0
+
+        delta = pushed - popped
+        spread = max(abs(pushed), abs(popped))
+        confidence = 0.5 if spread else 0.25
+
+        minimum = -popped
+        maximum = pushed
+
+        return cls(nominal=delta, minimum=minimum, maximum=maximum, confidence=confidence)
+
+    def widen(self, amount: int) -> "StackEffectHint":
+        """Return a new hint with an expanded range.
+
+        Some instructions (for example polymorphic reducers) have a mode-dependent
+        stack delta.  The knowledge database can mark such cases by creating a
+        neutral hint and letting the classifier widen the range when a specific
+        mode is encountered.
+        """
+
+        return StackEffectHint(
+            nominal=self.nominal,
+            minimum=self.minimum - amount,
+            maximum=self.maximum + amount,
+            confidence=self.confidence * 0.9,
+        )
+
+
+@dataclass
+class InstructionProfile:
+    """Bundle low level instruction details with analysis helpers."""
+
+    word: InstructionWord
+    info: Optional[OpcodeInfo]
+    mnemonic: str
+    summary: Optional[str]
+    category: Optional[str]
+    control_flow: Optional[str]
+    stack_hint: StackEffectHint
+    kind: InstructionKind
+    traits: Mapping[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_word(cls, word: InstructionWord, knowledge: KnowledgeBase) -> "InstructionProfile":
+        """Create a profile for ``word`` using ``knowledge`` annotations."""
+
+        info = knowledge.lookup(word.label())
+        mnemonic = info.mnemonic if info else f"op_{word.opcode:02X}_{word.mode:02X}"
+        summary = info.summary if info else None
+        category = info.category if info else None
+        control_flow = info.control_flow if info else None
+        stack_hint = StackEffectHint.from_info(info)
+        kind = classify_kind(word, info)
+        traits = info.attributes if info else {}
+        return cls(
+            word=word,
+            info=info,
+            mnemonic=mnemonic,
+            summary=summary,
+            category=category,
+            control_flow=control_flow,
+            stack_hint=stack_hint,
+            kind=kind,
+            traits=traits,
+        )
+
+    @property
+    def label(self) -> str:
+        return self.word.label()
+
+    @property
+    def opcode(self) -> int:
+        return self.word.opcode
+
+    @property
+    def mode(self) -> int:
+        return self.word.mode
+
+    @property
+    def operand(self) -> int:
+        return self.word.operand
+
+    def estimated_stack_delta(self) -> StackEffectHint:
+        """Return the stack hint adjusted by heuristics."""
+
+        hint = self.stack_hint
+        modifier = heuristic_stack_adjustment(self)
+        if modifier is None:
+            return hint
+        nominal = hint.nominal + modifier
+        return StackEffectHint(
+            nominal=nominal,
+            minimum=hint.minimum + modifier,
+            maximum=hint.maximum + modifier,
+            confidence=min(1.0, hint.confidence + 0.1),
+        )
+
+    def is_control(self) -> bool:
+        return self.kind in {InstructionKind.CONTROL, InstructionKind.BRANCH, InstructionKind.TERMINATOR}
+
+    def is_terminator(self) -> bool:
+        return self.kind is InstructionKind.TERMINATOR
+
+    def describe(self) -> str:
+        """Return a debugging string summarising the profile."""
+
+        return (
+            f"{self.word.offset:08X} {self.label:<7} {self.kind.name:<14} "
+            f"stack≈{self.stack_hint.nominal:+d}"
+        )
+
+
+def classify_kind(word: InstructionWord, info: Optional[OpcodeInfo]) -> InstructionKind:
+    """Classify ``word`` using ``info`` heuristics."""
+
+    if info is None:
+        return guess_kind_from_opcode(word)
+
+    if info.control_flow:
+        control = info.control_flow.lower()
+        if "return" in control:
+            return InstructionKind.RETURN
+        if "terminator" in control or "halt" in control:
+            return InstructionKind.TERMINATOR
+        if "branch" in control or "jump" in control:
+            return InstructionKind.BRANCH
+        if "call" in control:
+            if "tail" in (info.category or ""):
+                return InstructionKind.TAILCALL
+            return InstructionKind.CALL
+        if "control" in control:
+            return InstructionKind.CONTROL
+
+    if info.category:
+        category = info.category.lower()
+        if "literal" in category:
+            return InstructionKind.LITERAL
+        if "ascii" in category:
+            return InstructionKind.ASCII_CHUNK
+        if "push" in category:
+            return InstructionKind.PUSH
+        if "reduce" in category or "fold" in category:
+            return InstructionKind.REDUCE
+        if "teardown" in category or "pop" in category:
+            return InstructionKind.STACK_TEARDOWN
+        if "copy" in category or "dup" in category:
+            return InstructionKind.STACK_COPY
+        if "test" in category:
+            return InstructionKind.TEST
+        if "indirect" in category or "table" in category:
+            return InstructionKind.INDIRECT
+        if "tailcall" in category:
+            return InstructionKind.TAILCALL
+        if "return" in category:
+            return InstructionKind.RETURN
+        if "terminator" in category:
+            return InstructionKind.TERMINATOR
+
+    mnemonic = (info.mnemonic or "").lower()
+    summary = (info.summary or "").lower()
+
+    for source in (mnemonic, summary):
+        if not source:
+            continue
+        if "literal" in source or "const" in source:
+            return InstructionKind.LITERAL
+        if "push" in source and "stack" in source:
+            return InstructionKind.PUSH
+        if "reduce" in source or "fold" in source:
+            return InstructionKind.REDUCE
+        if "test" in source and "branch" in source:
+            return InstructionKind.TEST
+        if "stack" in source and ("clear" in source or "teardown" in source or "drop" in source):
+            return InstructionKind.STACK_TEARDOWN
+        if "duplicate" in source or "copy" in source:
+            return InstructionKind.STACK_COPY
+        if "table" in source or "index" in source:
+            return InstructionKind.TABLE_LOOKUP
+        if "arith" in source or "math" in source:
+            return InstructionKind.ARITHMETIC
+        if "logic" in source or "boolean" in source:
+            return InstructionKind.LOGICAL
+        if "bit" in source:
+            return InstructionKind.BITWISE
+        if "meta" in source or "helper" in source:
+            return InstructionKind.META
+
+    return guess_kind_from_opcode(word)
+
+
+def guess_kind_from_opcode(word: InstructionWord) -> InstructionKind:
+    """Fallback heuristic when no manual metadata is available."""
+
+    opcode = word.opcode
+    mode = word.mode
+
+    if opcode in {0x29, 0x30}:
+        if mode in {0x00, 0x10, 0x30, 0x69}:
+            return InstructionKind.TERMINATOR
+        return InstructionKind.RETURN
+
+    if opcode in {0x22, 0x23, 0x24, 0x25, 0x26, 0x27}:
+        return InstructionKind.BRANCH
+
+    if opcode in {0x16}:
+        return InstructionKind.CALL
+
+    if opcode in {0x41, 0x47, 0x90, 0xDC, 0xF4}:
+        return InstructionKind.ASCII_CHUNK
+
+    if opcode in {0x01}:
+        return InstructionKind.STACK_TEARDOWN
+
+    if opcode in {0x02, 0x03}:
+        return InstructionKind.PUSH
+
+    if opcode in {0x04}:
+        return InstructionKind.REDUCE
+
+    if opcode in {0x05, 0x06, 0x07, 0x08}:
+        return InstructionKind.ARITHMETIC
+
+    return InstructionKind.UNKNOWN
+
+
+def heuristic_stack_adjustment(profile: InstructionProfile) -> Optional[int]:
+    """Return additional stack delta adjustments derived from heuristics."""
+
+    kind = profile.kind
+    word = profile.word
+
+    if kind is InstructionKind.ASCII_CHUNK and profile.stack_hint.nominal == 0:
+        return 1
+
+    if kind is InstructionKind.LITERAL and profile.stack_hint.nominal == 0:
+        return 1
+
+    if kind is InstructionKind.PUSH and profile.stack_hint.nominal == 0:
+        return 1
+
+    if kind in {InstructionKind.STACK_TEARDOWN, InstructionKind.REDUCE} and profile.stack_hint.nominal == 0:
+        return -1
+
+    if kind is InstructionKind.TABLE_LOOKUP and profile.stack_hint.nominal == 0:
+        return 0
+
+    if kind is InstructionKind.TEST and profile.stack_hint.nominal == 0:
+        return -1 if word.mode & 0x01 else 0
+
+    if kind in {InstructionKind.CALL, InstructionKind.TAILCALL} and profile.stack_hint.nominal == 0:
+        return 0
+
+    return None
+
+
+def summarise_profiles(profiles: Sequence[InstructionProfile]) -> Mapping[InstructionKind, int]:
+    """Return a histogram of instruction kinds in ``profiles``."""
+
+    histogram: dict[InstructionKind, int] = {}
+    for profile in profiles:
+        histogram[profile.kind] = histogram.get(profile.kind, 0) + 1
+    return histogram
+
+
+def dominant_kind(profiles: Sequence[InstructionProfile]) -> InstructionKind:
+    """Return the most common instruction kind in ``profiles``."""
+
+    histogram = summarise_profiles(profiles)
+    if not histogram:
+        return InstructionKind.UNKNOWN
+    return max(histogram.items(), key=lambda item: item[1])[0]
+
+
+def filter_profiles(
+    profiles: Sequence[InstructionProfile], kinds: Iterable[InstructionKind]
+) -> Tuple[InstructionProfile, ...]:
+    """Return a tuple with the profiles matching ``kinds``."""
+
+    allowed = set(kinds)
+    return tuple(profile for profile in profiles if profile.kind in allowed)

--- a/mbcdisasm/analyzer/patterns.py
+++ b/mbcdisasm/analyzer/patterns.py
@@ -1,0 +1,325 @@
+"""Pipeline pattern recognition helpers.
+
+The module defines a declarative representation for instruction pipelines.  Each
+:class:`PipelinePattern` consists of :class:`PatternToken` objects that describe
+the expected instruction kinds, stack deltas and auxiliary constraints.  The
+pipeline analyser compiles these patterns into deterministic finite automata that
+can quickly scan long segments.  The actual matching logic is intentionally kept
+human readable to make it easier to tweak heuristics without having to rewrite
+large chunks of code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from .instruction_profile import InstructionKind
+from .stack import StackEvent
+
+
+@dataclass(frozen=True)
+class PatternToken:
+    """Describe a single position in a pipeline pattern."""
+
+    kinds: Tuple[InstructionKind, ...]
+    min_delta: int = -999
+    max_delta: int = 999
+    allow_unknown: bool = False
+    description: str = ""
+
+    def matches(self, event: StackEvent) -> bool:
+        """Return ``True`` if ``event`` satisfies this token."""
+
+        if not self.allow_unknown and event.profile.kind is InstructionKind.UNKNOWN:
+            return False
+        if self.kinds and event.profile.kind not in self.kinds:
+            return False
+        if event.delta < self.min_delta or event.delta > self.max_delta:
+            return False
+        return True
+
+    def describe(self) -> str:
+        names = ",".join(kind.name for kind in self.kinds) if self.kinds else "*"
+        return f"token({names} Δ∈[{self.min_delta},{self.max_delta}])"
+
+
+@dataclass(frozen=True)
+class PipelinePattern:
+    """Declarative description of a known pipeline form."""
+
+    name: str
+    category: str
+    tokens: Tuple[PatternToken, ...]
+    allow_extra: bool = False
+    stack_change: Optional[int] = None
+    description: str = ""
+
+    def match(self, events: Sequence[StackEvent]) -> Optional["PatternMatch"]:
+        """Return a :class:`PatternMatch` if ``events`` fit the pattern."""
+
+        if len(events) < len(self.tokens):
+            return None
+
+        slices = events[: len(self.tokens)]
+        for token, event in zip(self.tokens, slices):
+            if not token.matches(event):
+                return None
+
+        if not self.allow_extra and len(events) != len(self.tokens):
+            return None
+
+        if self.stack_change is not None:
+            delta = sum(event.delta for event in events)
+            if delta != self.stack_change:
+                return None
+
+        score = 1.0
+        if any(event.uncertain for event in events):
+            score *= 0.85
+        if any(event.profile.kind is InstructionKind.UNKNOWN for event in events):
+            score *= 0.5
+
+        return PatternMatch(pattern=self, events=tuple(events), score=score)
+
+    def describe(self) -> str:
+        return f"pattern {self.name} ({self.category})"
+
+
+@dataclass(frozen=True)
+class PatternMatch:
+    """Result of a pattern match."""
+
+    pattern: PipelinePattern
+    events: Tuple[StackEvent, ...]
+    score: float
+
+    def span(self) -> Tuple[int, int]:
+        start = self.events[0].profile.word.offset
+        end = self.events[-1].profile.word.offset
+        return start, end
+
+    def describe(self) -> str:
+        return f"{self.pattern.name} score={self.score:.2f}"
+
+
+class PatternRegistry:
+    """Container for all available patterns."""
+
+    def __init__(self, patterns: Optional[Iterable[PipelinePattern]] = None) -> None:
+        self._patterns: List[PipelinePattern] = list(patterns or [])
+
+    def add(self, pattern: PipelinePattern) -> None:
+        self._patterns.append(pattern)
+
+    def extend(self, patterns: Iterable[PipelinePattern]) -> None:
+        for pattern in patterns:
+            self.add(pattern)
+
+    def __iter__(self) -> Iterable[PipelinePattern]:
+        return iter(self._patterns)
+
+    def best_match(self, events: Sequence[StackEvent]) -> Optional[PatternMatch]:
+        """Return the best scoring pattern for ``events``."""
+
+        best: Optional[PatternMatch] = None
+        for pattern in self._patterns:
+            match = pattern.match(events)
+            if match is None:
+                continue
+            if best is None or match.score > best.score:
+                best = match
+        return best
+
+
+def default_patterns() -> PatternRegistry:
+    """Return a :class:`PatternRegistry` populated with built-in patterns."""
+
+    registry = PatternRegistry()
+    registry.extend(
+        [
+            literal_pipeline(),
+            ascii_pipeline(),
+            reduce_pipeline(),
+            call_preparation_pipeline(),
+            return_pipeline(),
+            indirect_load_pipeline(),
+        ]
+    )
+    return registry
+
+
+def literal_pipeline() -> PipelinePattern:
+    """Return the pattern for ``literal -> push -> test`` style blocks."""
+
+    tokens = (
+        PatternToken(
+            kinds=(InstructionKind.LITERAL, InstructionKind.ASCII_CHUNK),
+            min_delta=1,
+            description="literal load",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.PUSH,),
+            min_delta=1,
+            description="stack push",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.TEST, InstructionKind.BRANCH),
+            min_delta=-1,
+            max_delta=0,
+            description="test/branch",
+        ),
+    )
+    return PipelinePattern(
+        name="literal_push_test",
+        category="literal",
+        tokens=tokens,
+        stack_change=1,
+        description="Load literal value, push to stack, perform test",
+    )
+
+
+def ascii_pipeline() -> PipelinePattern:
+    """Return the pattern for inline ASCII chunk loaders."""
+
+    tokens = (
+        PatternToken(
+            kinds=(InstructionKind.ASCII_CHUNK,),
+            min_delta=1,
+            description="ascii chunk load",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.REDUCE,),
+            min_delta=-3,
+            max_delta=-1,
+            description="chunk reducer",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.PUSH,),
+            min_delta=1,
+            description="push reduced value",
+        ),
+    )
+    return PipelinePattern(
+        name="ascii_reduce_push",
+        category="literal",
+        tokens=tokens,
+        stack_change=-1,
+        description="Load ASCII chunk and collapse into a single value",
+    )
+
+
+def reduce_pipeline() -> PipelinePattern:
+    """Return a pattern for multi-argument reducers."""
+
+    tokens = (
+        PatternToken(
+            kinds=(InstructionKind.PUSH, InstructionKind.LITERAL),
+            min_delta=1,
+            description="operand feed",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.PUSH, InstructionKind.LITERAL),
+            min_delta=1,
+            description="operand feed",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.REDUCE,),
+            min_delta=-2,
+            max_delta=-1,
+            description="reduce",
+        ),
+    )
+    return PipelinePattern(
+        name="reduce_chain",
+        category="compute",
+        tokens=tokens,
+        allow_extra=True,
+        description="Feed operands then reduce",
+    )
+
+
+def call_preparation_pipeline() -> PipelinePattern:
+    """Return the pattern for call frame initialisation."""
+
+    tokens = (
+        PatternToken(
+            kinds=(InstructionKind.PUSH, InstructionKind.LITERAL, InstructionKind.TABLE_LOOKUP),
+            min_delta=1,
+            description="operand push",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.PUSH, InstructionKind.LITERAL, InstructionKind.TABLE_LOOKUP),
+            min_delta=0,
+            max_delta=2,
+            description="additional operands",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.CALL, InstructionKind.TAILCALL, InstructionKind.META),
+            min_delta=-1,
+            max_delta=1,
+            description="call helper",
+        ),
+    )
+    return PipelinePattern(
+        name="call_preparation",
+        category="call",
+        tokens=tokens,
+        allow_extra=True,
+        description="Prepare call frame and invoke helper",
+    )
+
+
+def return_pipeline() -> PipelinePattern:
+    """Return the pattern describing teardown/return sequences."""
+
+    tokens = (
+        PatternToken(
+            kinds=(InstructionKind.STACK_TEARDOWN,),
+            min_delta=-4,
+            max_delta=-1,
+            description="frame teardown",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.RETURN, InstructionKind.TERMINATOR),
+            min_delta=-2,
+            max_delta=0,
+            description="return/terminator",
+        ),
+    )
+    return PipelinePattern(
+        name="return_teardown",
+        category="return",
+        tokens=tokens,
+        allow_extra=True,
+        description="Drop frame values and return",
+    )
+
+
+def indirect_load_pipeline() -> PipelinePattern:
+    """Return the pattern for table/indirect loads."""
+
+    tokens = (
+        PatternToken(
+            kinds=(InstructionKind.PUSH, InstructionKind.LITERAL),
+            min_delta=1,
+            description="base push",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.PUSH, InstructionKind.LITERAL),
+            min_delta=1,
+            description="key push",
+        ),
+        PatternToken(
+            kinds=(InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP),
+            min_delta=-1,
+            max_delta=0,
+            description="indirect read",
+        ),
+    )
+    return PipelinePattern(
+        name="indirect_lookup",
+        category="indirect",
+        tokens=tokens,
+        description="Push base/key then resolve table entry",
+    )

--- a/mbcdisasm/analyzer/pipeline.py
+++ b/mbcdisasm/analyzer/pipeline.py
@@ -1,0 +1,189 @@
+"""High level orchestration for pipeline analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from ..instruction import InstructionWord
+from ..knowledge import KnowledgeBase
+from .instruction_profile import (
+    InstructionKind,
+    InstructionProfile,
+    dominant_kind,
+)
+from .diagnostics import DiagnosticBuilder
+from .dfa import DeterministicAutomaton
+from .heuristics import HeuristicEngine, HeuristicReport
+from .patterns import PatternMatch, PatternRegistry, default_patterns
+from .stats import StatisticsBuilder
+from .report import PipelineBlock, PipelineReport, build_block
+from .stack import StackEvent, StackSummary, StackTracker
+
+
+@dataclass
+class AnalyzerSettings:
+    """Configuration knobs for :class:`PipelineAnalyzer`."""
+
+    max_window: int = 6
+    min_confidence: float = 0.35
+    stack_change_bias: float = 0.05
+
+
+class PipelineAnalyzer:
+    """Analyse instruction streams and recover high level pipeline blocks."""
+
+    def __init__(
+        self,
+        knowledge: KnowledgeBase,
+        *,
+        settings: Optional[AnalyzerSettings] = None,
+        patterns: Optional[PatternRegistry] = None,
+    ) -> None:
+        self.knowledge = knowledge
+        self.settings = settings or AnalyzerSettings()
+        self.registry = patterns or default_patterns()
+        self.heuristics = HeuristicEngine()
+        self.diagnostics = DiagnosticBuilder()
+        self.statistics_builder = StatisticsBuilder()
+        self.automaton = DeterministicAutomaton(self.registry)
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def analyse_segment(self, instructions: Sequence[InstructionWord]) -> PipelineReport:
+        profiles = self._profile_instructions(instructions)
+        if not profiles:
+            return PipelineReport.empty()
+        events = self._compute_events(profiles)
+        blocks = self._segment_into_blocks(profiles, events)
+        warnings = self._generate_warnings(blocks)
+        statistics = self.statistics_builder.collect(blocks)
+        return PipelineReport(blocks=tuple(blocks), warnings=tuple(warnings), statistics=statistics)
+
+    analyze_segment = analyse_segment  # alias for US spelling
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _profile_instructions(self, instructions: Sequence[InstructionWord]) -> Tuple[InstructionProfile, ...]:
+        return tuple(InstructionProfile.from_word(word, self.knowledge) for word in instructions)
+
+    def _compute_events(self, profiles: Sequence[InstructionProfile]) -> Tuple[StackEvent, ...]:
+        tracker = StackTracker()
+        events = [tracker.process(profile) for profile in profiles]
+        return tuple(events)
+
+    def _segment_into_blocks(
+        self,
+        profiles: Sequence[InstructionProfile],
+        events: Sequence[StackEvent],
+    ) -> List[PipelineBlock]:
+        blocks: List[PipelineBlock] = []
+        idx = 0
+        window = self.settings.max_window
+        total = len(profiles)
+        while idx < total:
+            best_match: Optional[PatternMatch] = None
+            best_span = 1
+            for size in range(2, window + 1):
+                end = idx + size
+                if end > total:
+                    break
+                slice_events = events[idx:end]
+                match = self.automaton.best_match(slice_events)
+                if match is None:
+                    continue
+                if best_match is None or match.score > best_match.score:
+                    best_match = match
+                    best_span = size
+            span = best_span
+            if best_match is None:
+                span = max(1, min(window, total - idx))
+            block_profiles = profiles[idx : idx + span]
+            stack_summary = StackTracker().process_block(block_profiles)
+            previous = profiles[idx - 1] if idx > 0 else None
+            following = profiles[idx + span] if idx + span < total else None
+            heuristic_report = self.heuristics.analyse(
+                block_profiles,
+                stack_summary,
+                previous=previous,
+                following=following,
+            )
+            category, confidence, notes = self._classify_block(
+                block_profiles,
+                stack_summary,
+                best_match,
+                heuristic_report,
+            )
+            notes.append(heuristic_report.describe())
+            block = build_block(block_profiles, stack_summary, best_match, category, confidence, notes)
+            blocks.append(block)
+            idx += span
+        return blocks
+
+    def _classify_block(
+        self,
+        profiles: Sequence[InstructionProfile],
+        stack: StackSummary,
+        match: Optional[PatternMatch],
+        heuristics: HeuristicReport,
+    ) -> Tuple[str, float, List[str]]:
+        notes: List[str] = []
+        if match is not None:
+            category = match.pattern.category
+            confidence = min(1.0, match.score)
+            if stack.uncertain:
+                confidence *= 0.85
+                notes.append("uncertain stack delta")
+            return category, confidence, notes
+
+        dominant = dominant_kind(profiles)
+        category = "unknown"
+        confidence = self.settings.min_confidence
+
+        if dominant in {InstructionKind.LITERAL, InstructionKind.ASCII_CHUNK, InstructionKind.PUSH}:
+            category = "literal"
+            confidence = 0.55
+        elif dominant in {InstructionKind.REDUCE, InstructionKind.ARITHMETIC}:
+            category = "compute"
+            confidence = 0.5
+        elif dominant in {InstructionKind.STACK_TEARDOWN, InstructionKind.RETURN, InstructionKind.TERMINATOR}:
+            category = "return"
+            confidence = 0.6
+        elif dominant in {InstructionKind.CALL, InstructionKind.TAILCALL}:
+            category = "call"
+            confidence = 0.6
+        elif dominant is InstructionKind.TEST:
+            category = "test"
+            confidence = 0.5
+        elif dominant in {InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP}:
+            category = "indirect"
+            confidence = 0.5
+
+        feature_map = heuristics.feature_map()
+
+        if "indirect_pattern" in feature_map:
+            category = "indirect"
+            confidence = max(confidence, 0.6)
+
+        if "call_helper" in feature_map:
+            category = "call"
+            confidence = max(confidence, 0.65)
+
+        if "return_sequence" in feature_map or "stack_teardown" in feature_map:
+            category = "return"
+            confidence = max(confidence, 0.6)
+
+        if stack.change > 0 and category == "compute":
+            notes.append("positive stack change in compute block")
+        if stack.change < 0 and category == "literal":
+            notes.append("literal block reduced stack")
+        if stack.uncertain:
+            confidence *= 0.85
+            notes.append("uncertain stack delta")
+        return category, confidence, notes
+
+    def _generate_warnings(self, blocks: Sequence[PipelineBlock]) -> List[str]:
+        report = self.diagnostics.evaluate(blocks)
+        return [entry.describe() for entry in report.filter("warning")]

--- a/mbcdisasm/analyzer/report.py
+++ b/mbcdisasm/analyzer/report.py
@@ -1,0 +1,116 @@
+"""Reporting structures for pipeline analysis results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from .instruction_profile import InstructionKind, InstructionProfile, dominant_kind
+from .patterns import PatternMatch
+from .stack import StackSummary
+from .stats import PipelineStatistics
+
+
+@dataclass
+class PipelineBlock:
+    """Description of a single pipeline block."""
+
+    profiles: Tuple[InstructionProfile, ...]
+    stack: StackSummary
+    kind: InstructionKind
+    category: str
+    pattern: Optional[PatternMatch] = None
+    confidence: float = 0.0
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def start_offset(self) -> int:
+        return self.profiles[0].word.offset if self.profiles else 0
+
+    @property
+    def end_offset(self) -> int:
+        return self.profiles[-1].word.offset if self.profiles else 0
+
+    def describe(self) -> str:
+        pattern = self.pattern.pattern.name if self.pattern else "?"
+        return (
+            f"[{self.start_offset:08X}-{self.end_offset:08X}] "
+            f"kind={self.kind.name} cat={self.category} "
+            f"stack={self.stack.describe()} pattern={pattern} conf={self.confidence:.2f}"
+        )
+
+    def histogram(self) -> dict[InstructionKind, int]:
+        counts: dict[InstructionKind, int] = {}
+        for profile in self.profiles:
+            counts[profile.kind] = counts.get(profile.kind, 0) + 1
+        return counts
+
+    def add_note(self, message: str) -> None:
+        self.notes.append(message)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "start_offset": self.start_offset,
+            "end_offset": self.end_offset,
+            "kind": self.kind.name,
+            "category": self.category,
+            "stack_change": self.stack.change,
+            "stack_min": self.stack.minimum,
+            "stack_max": self.stack.maximum,
+            "confidence": self.confidence,
+            "pattern": self.pattern.pattern.name if self.pattern else None,
+            "notes": list(self.notes),
+        }
+
+
+@dataclass
+class PipelineReport:
+    """Container for all blocks extracted from a segment."""
+
+    blocks: Tuple[PipelineBlock, ...]
+    warnings: Tuple[str, ...] = tuple()
+    statistics: Optional[PipelineStatistics] = None
+
+    def describe(self) -> str:
+        lines = ["Pipeline analysis report:"]
+        for block in self.blocks:
+            lines.append("  " + block.describe())
+        if self.warnings:
+            lines.append("Warnings:")
+            for warning in self.warnings:
+                lines.append("  - " + warning)
+        if self.statistics:
+            lines.append("Statistics: " + self.statistics.describe())
+        return "\n".join(lines)
+
+    def filter_by_category(self, category: str) -> Tuple[PipelineBlock, ...]:
+        return tuple(block for block in self.blocks if block.category == category)
+
+    def total_stack_change(self) -> int:
+        return sum(block.stack.change for block in self.blocks)
+
+    @classmethod
+    def empty(cls) -> "PipelineReport":
+        return cls(blocks=tuple(), warnings=tuple(), statistics=None)
+
+
+def build_block(
+    profiles: Sequence[InstructionProfile],
+    stack: StackSummary,
+    pattern: Optional[PatternMatch],
+    category: str,
+    confidence: float,
+    notes: Optional[Iterable[str]] = None,
+) -> PipelineBlock:
+    dominant = dominant_kind(profiles)
+    block = PipelineBlock(
+        profiles=tuple(profiles),
+        stack=stack,
+        kind=dominant,
+        category=category,
+        pattern=pattern,
+        confidence=confidence,
+    )
+    for note in notes or []:
+        block.add_note(note)
+    return block

--- a/mbcdisasm/analyzer/stack.py
+++ b/mbcdisasm/analyzer/stack.py
@@ -1,0 +1,203 @@
+"""Stack tracking primitives used by the pipeline analyser.
+
+The interpreter targeted by this project is stack based.  Every instruction
+manipulates the evaluation stack in highly constrained ways which makes the
+stack delta a reliable feature for classification.  The :class:`StackTracker`
+class included in this module keeps a running tally of the stack height while it
+visits the instruction stream.  The tracker is intentionally conservative: when
+ faced with ambiguous data it records a range instead of guessing.  Downstream
+consumers can then decide whether a block is reliable enough to be labelled as a
+literal loader or whether it should be flagged for manual review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+from .instruction_profile import InstructionKind, InstructionProfile, StackEffectHint
+
+
+@dataclass
+class StackEvent:
+    """Represents the effect of a single instruction on the stack."""
+
+    profile: InstructionProfile
+    delta: int
+    minimum: int
+    maximum: int
+    confidence: float
+    depth_before: int
+    depth_after: int
+    uncertain: bool = False
+
+    def describe(self) -> str:
+        return (
+            f"{self.profile.word.offset:08X} {self.profile.label:<7} "
+            f"Δ={self.delta:+d} range=({self.minimum:+d},{self.maximum:+d}) "
+            f"depth={self.depth_before}->{self.depth_after}"
+        )
+
+
+@dataclass
+class StackState:
+    """Running stack statistics."""
+
+    depth: int = 0
+    minimum_depth: int = 0
+    maximum_depth: int = 0
+    uncertain: bool = False
+
+    def apply(self, hint: StackEffectHint) -> Tuple[int, int, int, bool]:
+        """Apply ``hint`` and return the resulting statistics."""
+
+        minimum = self.depth + hint.minimum
+        maximum = self.depth + hint.maximum
+
+        after = self.depth + hint.nominal
+        self.depth = after
+        self.minimum_depth = min(self.minimum_depth, minimum)
+        self.maximum_depth = max(self.maximum_depth, maximum)
+        uncertainty = self.uncertain or hint.confidence < 0.75
+        self.uncertain = uncertainty
+        return minimum, maximum, after, uncertainty
+
+    def fork(self) -> "StackState":
+        """Return a copy of the state.
+
+        The method is handy for speculative flows where a caller wants to compute
+        the effect of several instructions without mutating the primary state.
+        """
+
+        return StackState(
+            depth=self.depth,
+            minimum_depth=self.minimum_depth,
+            maximum_depth=self.maximum_depth,
+            uncertain=self.uncertain,
+        )
+
+
+@dataclass
+class StackSummary:
+    """Aggregate statistics for a block of instructions."""
+
+    change: int
+    minimum: int
+    maximum: int
+    uncertain: bool
+    events: Tuple[StackEvent, ...]
+
+    def describe(self) -> str:
+        flag = "±" if self.uncertain else "="
+        return f"stack{flag}{self.change:+d} range=({self.minimum:+d},{self.maximum:+d})"
+
+
+class StackTracker:
+    """Track the stack height as instructions are processed."""
+
+    def __init__(self, initial_depth: int = 0) -> None:
+        self._state = StackState(depth=initial_depth)
+        self._events: List[StackEvent] = []
+
+    def process(self, profile: InstructionProfile) -> StackEvent:
+        """Process ``profile`` and record the resulting stack event."""
+
+        hint = profile.estimated_stack_delta()
+        minimum, maximum, after, uncertain = self._state.apply(hint)
+        event = StackEvent(
+            profile=profile,
+            delta=hint.nominal,
+            minimum=minimum,
+            maximum=maximum,
+            confidence=hint.confidence,
+            depth_before=after - hint.nominal,
+            depth_after=after,
+            uncertain=uncertain,
+        )
+        self._events.append(event)
+        return event
+
+    def run(self, profiles: Sequence[InstructionProfile]) -> StackSummary:
+        """Process ``profiles`` sequentially and return the summary."""
+
+        for profile in profiles:
+            self.process(profile)
+        return self.summarise()
+
+    def summarise(self) -> StackSummary:
+        """Return a :class:`StackSummary` covering all processed instructions."""
+
+        change = sum(event.delta for event in self._events)
+        if not self._events:
+            return StackSummary(change=0, minimum=0, maximum=0, uncertain=False, events=tuple())
+        minimum = min(event.minimum for event in self._events)
+        maximum = max(event.maximum for event in self._events)
+        uncertain = any(event.uncertain for event in self._events)
+        return StackSummary(
+            change=change,
+            minimum=minimum,
+            maximum=maximum,
+            uncertain=uncertain,
+            events=tuple(self._events),
+        )
+
+    def reset(self, depth: int = 0) -> None:
+        """Clear the recorded events and reset the depth."""
+
+        self._state = StackState(depth=depth)
+        self._events.clear()
+
+    def depth(self) -> int:
+        """Return the current stack depth estimate."""
+
+        return self._state.depth
+
+    def copy(self) -> "StackTracker":
+        """Return a duplicate tracker with the same state."""
+
+        clone = StackTracker()
+        clone._state = self._state.fork()
+        clone._events = list(self._events)
+        return clone
+
+    def process_block(self, profiles: Sequence[InstructionProfile]) -> StackSummary:
+        """Process ``profiles`` using a dedicated tracker copy."""
+
+        clone = self.copy()
+        summary = clone.run(profiles)
+        return StackSummary(
+            change=summary.change,
+            minimum=summary.minimum,
+            maximum=summary.maximum,
+            uncertain=summary.uncertain,
+            events=summary.events,
+        )
+
+
+def stack_change(profiles: Sequence[InstructionProfile]) -> int:
+    """Return the combined stack delta for ``profiles``."""
+
+    tracker = StackTracker()
+    summary = tracker.run(profiles)
+    return summary.change
+
+
+def contains_stack_teardown(profiles: Iterable[InstructionProfile]) -> bool:
+    """Return ``True`` if any profile represents a stack teardown operation."""
+
+    for profile in profiles:
+        if profile.kind is InstructionKind.STACK_TEARDOWN:
+            return True
+    return False
+
+
+def contains_literal_push(profiles: Iterable[InstructionProfile]) -> bool:
+    """Return ``True`` if the block looks like a literal/push sequence."""
+
+    literal_like = {
+        InstructionKind.LITERAL,
+        InstructionKind.ASCII_CHUNK,
+        InstructionKind.PUSH,
+        InstructionKind.TABLE_LOOKUP,
+    }
+    return any(profile.kind in literal_like for profile in profiles)

--- a/mbcdisasm/analyzer/stats.py
+++ b/mbcdisasm/analyzer/stats.py
@@ -1,0 +1,106 @@
+"""Aggregated statistics for pipeline analysis runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, Mapping, Optional, Sequence
+
+from .instruction_profile import InstructionKind
+
+if TYPE_CHECKING:  # pragma: no cover - type checking helper
+    from .report import PipelineBlock
+
+
+@dataclass
+class CategoryStats:
+    """Aggregated information about a single block category."""
+
+    count: int = 0
+    stack_delta: int = 0
+    stack_abs: int = 0
+
+    def record(self, block: "PipelineBlock") -> None:
+        self.count += 1
+        self.stack_delta += block.stack.change
+        self.stack_abs += abs(block.stack.change)
+
+    def average_delta(self) -> float:
+        if not self.count:
+            return 0.0
+        return self.stack_delta / self.count
+
+    def describe(self) -> str:
+        return f"count={self.count} delta={self.stack_delta:+d}"
+
+
+@dataclass
+class KindStats:
+    """Aggregated statistics keyed by :class:`InstructionKind`."""
+
+    counts: Dict[InstructionKind, int] = field(default_factory=dict)
+
+    def record(self, kind: InstructionKind, amount: int = 1) -> None:
+        self.counts[kind] = self.counts.get(kind, 0) + amount
+
+    def most_common(self) -> Optional[InstructionKind]:
+        if not self.counts:
+            return None
+        return max(self.counts.items(), key=lambda item: item[1])[0]
+
+    def describe(self) -> str:
+        parts = [f"{kind.name}:{count}" for kind, count in sorted(self.counts.items(), key=lambda item: item[1], reverse=True)]
+        return "{" + ", ".join(parts) + "}"
+
+
+@dataclass
+class PipelineStatistics:
+    """Aggregated view of a full pipeline analysis run."""
+
+    block_count: int
+    instruction_count: int
+    total_stack_delta: int
+    categories: Mapping[str, CategoryStats]
+    kinds: KindStats
+
+    def category_ratio(self, category: str) -> float:
+        stats = self.categories.get(category)
+        if not stats or not self.block_count:
+            return 0.0
+        return stats.count / self.block_count
+
+    def dominant_category(self) -> Optional[str]:
+        if not self.categories:
+            return None
+        return max(self.categories.items(), key=lambda item: item[1].count)[0]
+
+    def describe(self) -> str:
+        pieces = [f"blocks={self.block_count}", f"instr={self.instruction_count}", f"stackΔ={self.total_stack_delta:+d}"]
+        for category, stats in self.categories.items():
+            pieces.append(f"{category}:{stats.count}")
+        pieces.append("kinds=" + self.kinds.describe())
+        return " ".join(pieces)
+
+
+class StatisticsBuilder:
+    """Compute :class:`PipelineStatistics` from pipeline blocks."""
+
+    def collect(self, blocks: Sequence["PipelineBlock"]) -> PipelineStatistics:
+        categories: Dict[str, CategoryStats] = {}
+        kind_stats = KindStats()
+        instruction_count = 0
+        total_delta = 0
+
+        for block in blocks:
+            instruction_count += len(block.profiles)
+            total_delta += block.stack.change
+            categories.setdefault(block.category, CategoryStats()).record(block)
+            for profile in block.profiles:
+                kind_stats.record(profile.kind)
+
+        return PipelineStatistics(
+            block_count=len(blocks),
+            instruction_count=instruction_count,
+            total_stack_delta=total_delta,
+            categories=categories,
+            kinds=kind_stats,
+        )

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,78 @@
+from mbcdisasm.analyzer import PipelineAnalyzer
+from mbcdisasm.instruction import InstructionWord
+from mbcdisasm.knowledge import KnowledgeBase, OpcodeInfo
+
+
+def make_word(offset: int, opcode: int, mode: int = 0, operand: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def build_knowledge() -> KnowledgeBase:
+    annotations = {
+        "10:00": OpcodeInfo(mnemonic="literal", summary="literal load", category="literal", stack_delta=1),
+        "11:00": OpcodeInfo(mnemonic="push", summary="stack push", category="push", stack_delta=1),
+        "12:00": OpcodeInfo(
+            mnemonic="test_branch",
+            summary="test",
+            control_flow="branch",
+            category="test",
+            stack_delta=-1,
+        ),
+        "20:00": OpcodeInfo(mnemonic="reduce", summary="reduce", category="reduce", stack_delta=-2),
+        "21:00": OpcodeInfo(mnemonic="call_helper", summary="call", control_flow="call", category="call"),
+        "30:00": OpcodeInfo(
+            mnemonic="teardown",
+            summary="teardown",
+            category="stack_teardown",
+            stack_delta=-2,
+        ),
+        "31:00": OpcodeInfo(
+            mnemonic="return",
+            summary="return",
+            control_flow="return",
+            category="return",
+            stack_delta=-1,
+        ),
+    }
+    return KnowledgeBase(annotations)
+
+
+def test_literal_pipeline_detection():
+    analyzer = PipelineAnalyzer(build_knowledge())
+    instructions = [
+        make_word(0, 0x10),
+        make_word(4, 0x11),
+        make_word(8, 0x12),
+    ]
+    report = analyzer.analyse_segment(instructions)
+    assert report.blocks
+    first = report.blocks[0]
+    assert first.category == "literal"
+    assert first.pattern is not None
+    assert first.pattern.pattern.name == "literal_push_test"
+    assert report.statistics is not None
+    assert report.statistics.block_count == len(report.blocks)
+
+
+def test_call_pipeline_detection():
+    analyzer = PipelineAnalyzer(build_knowledge())
+    instructions = [
+        make_word(0, 0x10),
+        make_word(4, 0x11),
+        make_word(8, 0x21),
+    ]
+    report = analyzer.analyse_segment(instructions)
+    assert any(block.category == "call" for block in report.blocks)
+
+
+def test_return_pipeline_detection():
+    analyzer = PipelineAnalyzer(build_knowledge())
+    instructions = [
+        make_word(0, 0x30),
+        make_word(4, 0x31),
+    ]
+    report = analyzer.analyse_segment(instructions)
+    categories = [block.category for block in report.blocks]
+    assert "return" in categories
+    assert report.total_stack_change() <= 0


### PR DESCRIPTION
## Summary
- introduce the `mbcdisasm.analyzer` package with instruction profiling, stack tracking, DFA pattern matching, heuristics, diagnostics, and statistics utilities for recognising execution pipelines
- extend opcode metadata loading to expose stack/control annotations and document the VM invariants and analyser in the README
- cover the new analyser with unit tests that exercise literal, call, and return pipelines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd491276c832fa06984fc78a396f6