### PR TITLE
Enhance analyzer stability with lexicon and block refinement

### DIFF
--- a/mbcdisasm/analyzer/__init__.py
+++ b/mbcdisasm/analyzer/__init__.py
@@ -43,5 +43,15 @@ patterns that need manual review.
 
 from .pipeline import PipelineAnalyzer
 from .report import PipelineBlock, PipelineReport
+from .comparison import ReportComparator, describe_diff
+from .insights import build_report_table, format_report_table
 
-__all__ = ["PipelineAnalyzer", "PipelineBlock", "PipelineReport"]
+__all__ = [
+    "PipelineAnalyzer",
+    "PipelineBlock",
+    "PipelineReport",
+    "ReportComparator",
+    "describe_diff",
+    "build_report_table",
+    "format_report_table",
+]

--- a/mbcdisasm/analyzer/block_refiner.py
+++ b/mbcdisasm/analyzer/block_refiner.py
@@ -1,0 +1,264 @@
+"""Post-processing helpers for pipeline blocks.
+
+The :class:`~mbcdisasm.analyzer.pipeline.PipelineAnalyzer` focuses on recognising
+short instruction windows and assigning a coarse category.  In practice the
+initial classification may leave small marker-only blocks labelled as
+``unknown`` or assign a low confidence score to literal loaders that are wrapped
+in descriptive metadata.  The block refiner performs a secondary pass that
+stabilises those classifications and merges contextual information exposed by the
+heuristic engine.
+
+The refiner is intentionally conservative – it never invents new instructions or
+rewrites the stack deltas.  Instead it adjusts the block metadata (category,
+confidence and notes) to better reflect the observed instruction mix.  The logic
+encoded here mirrors the heuristics used during manual reversing sessions and is
+heavily documented so that contributors can audit the decision making process.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+from .instruction_profile import InstructionKind
+from .report import PipelineBlock
+
+__all__ = ["BlockSignature", "RefinementSettings", "RefinementSummary", "BlockRefiner"]
+
+
+# ---------------------------------------------------------------------------
+# Lightweight signature describing the instruction mix of a block
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class BlockSignature:
+    """Summary statistics for a :class:`PipelineBlock`.
+
+    The signature tracks how many instructions fall into each high level kind
+    which allows the refiner to reason about the dominant behaviour of a block.
+    Consumers can treat the signature as an immutable value object and derive
+    additional metrics such as literal or marker density.
+    """
+
+    literal: int
+    markers: int
+    pushes: int
+    ascii_chunks: int
+    reducers: int
+    returns: int
+    controls: int
+    unknown: int
+    total: int
+
+    @classmethod
+    def from_block(cls, block: PipelineBlock) -> "BlockSignature":
+        literal = markers = pushes = ascii_chunks = reducers = returns = controls = unknown = 0
+        for profile in block.profiles:
+            kind = profile.kind
+            if kind is InstructionKind.LITERAL:
+                literal += 1
+            elif kind is InstructionKind.MARKER:
+                markers += 1
+            elif kind is InstructionKind.PUSH:
+                pushes += 1
+            elif kind is InstructionKind.ASCII_CHUNK:
+                ascii_chunks += 1
+            elif kind is InstructionKind.REDUCE:
+                reducers += 1
+            elif kind in {InstructionKind.RETURN, InstructionKind.TERMINATOR}:
+                returns += 1
+            elif kind in {InstructionKind.BRANCH, InstructionKind.CONTROL}:
+                controls += 1
+            elif kind is InstructionKind.UNKNOWN:
+                unknown += 1
+        total = len(block.profiles)
+        return cls(
+            literal=literal,
+            markers=markers,
+            pushes=pushes,
+            ascii_chunks=ascii_chunks,
+            reducers=reducers,
+            returns=returns,
+            controls=controls,
+            unknown=unknown,
+            total=total,
+        )
+
+    # ------------------------------------------------------------------
+    # convenience metrics
+    # ------------------------------------------------------------------
+    def literal_density(self) -> float:
+        if not self.total:
+            return 0.0
+        return (self.literal + self.pushes + self.ascii_chunks) / self.total
+
+    def marker_density(self) -> float:
+        if not self.total:
+            return 0.0
+        return self.markers / self.total
+
+    def unknown_ratio(self) -> float:
+        if not self.total:
+            return 0.0
+        return self.unknown / self.total
+
+    def return_ratio(self) -> float:
+        if not self.total:
+            return 0.0
+        return self.returns / self.total
+
+    def describe(self) -> str:
+        return (
+            f"literal={self.literal} markers={self.markers} pushes={self.pushes} "
+            f"ascii={self.ascii_chunks} reducers={self.reducers} returns={self.returns} "
+            f"unknown={self.unknown}/{self.total}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Refinement settings
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RefinementSettings:
+    """Configuration object controlling the :class:`BlockRefiner`."""
+
+    literal_threshold: float = 0.55
+    marker_threshold: float = 0.4
+    return_threshold: float = 0.2
+    min_confidence: float = 0.45
+    marker_confidence: float = 0.6
+    literal_confidence: float = 0.65
+    return_confidence: float = 0.7
+
+
+class BlockRefiner:
+    """Adjust block metadata to improve classification stability."""
+
+    def __init__(self, settings: RefinementSettings | None = None) -> None:
+        self.settings = settings or RefinementSettings()
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def refine(self, blocks: Sequence[PipelineBlock]) -> Tuple[PipelineBlock, ...]:
+        refined: List[PipelineBlock] = []
+        total = len(blocks)
+        for index, block in enumerate(blocks):
+            signature = BlockSignature.from_block(block)
+            previous = refined[index - 1] if index > 0 else None
+            following = blocks[index + 1] if index + 1 < total else None
+            self._reclassify(block, signature)
+            self._stabilise_confidence(block, signature)
+            self._propagate_context(block, signature, previous, following)
+            refined.append(block)
+        return tuple(refined)
+
+    def summarise(self, blocks: Sequence[PipelineBlock]) -> RefinementSummary:
+        literal = return_blocks = control = unknown = 0
+        for block in blocks:
+            if block.category == "literal":
+                literal += 1
+            elif block.category == "return":
+                return_blocks += 1
+            elif block.category == "control":
+                control += 1
+            elif block.category == "unknown":
+                unknown += 1
+        return RefinementSummary(
+            literal_blocks=literal,
+            return_blocks=return_blocks,
+            control_blocks=control,
+            unknown_blocks=unknown,
+        )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _reclassify(self, block: PipelineBlock, signature: BlockSignature) -> None:
+        """Assign a better suited category based on the block signature."""
+
+        if signature.total == 0:
+            return
+
+        literal_density = signature.literal_density()
+        marker_density = signature.marker_density()
+        return_density = signature.return_ratio()
+
+        if marker_density >= self.settings.marker_threshold and literal_density >= 0.3:
+            block.category = "literal"
+            block.add_note("refiner: marker-dense literal block")
+        elif literal_density >= self.settings.literal_threshold:
+            block.category = "literal"
+            block.add_note("refiner: literal density threshold exceeded")
+        elif return_density >= self.settings.return_threshold or signature.returns:
+            block.category = "return"
+            block.add_note("refiner: return signature detected")
+        elif signature.controls and block.category == "unknown":
+            block.category = "control"
+            block.add_note("refiner: promoted to control due to neighbouring opcodes")
+
+        if signature.markers and block.category == "unknown":
+            block.category = "literal"
+            block.add_note("refiner: marker-only block interpreted as literal metadata")
+
+    def _stabilise_confidence(self, block: PipelineBlock, signature: BlockSignature) -> None:
+        """Ensure that the confidence matches the refined category."""
+
+        baseline = max(self.settings.min_confidence, block.confidence)
+        if block.category == "literal":
+            target = max(baseline, self.settings.literal_confidence)
+            if signature.marker_density() >= self.settings.marker_threshold:
+                target = max(target, self.settings.marker_confidence)
+            block.confidence = target
+        elif block.category == "return":
+            target = max(baseline, self.settings.return_confidence)
+            block.confidence = target
+        elif block.category == "control" and signature.controls:
+            block.confidence = max(baseline, 0.55)
+        else:
+            block.confidence = baseline
+
+        block.add_note(f"refiner: signature {signature.describe()}")
+
+    def _propagate_context(
+        self,
+        block: PipelineBlock,
+        signature: BlockSignature,
+        previous: PipelineBlock | None,
+        following: PipelineBlock | None,
+    ) -> None:
+        """Adjust block metadata using neighbouring information."""
+
+        if previous and previous.category == block.category:
+            block.confidence = max(block.confidence, previous.confidence * 0.95)
+            block.add_note("refiner: confidence aligned with previous block")
+        if following and following.category == block.category:
+            block.confidence = max(block.confidence, following.confidence * 0.95)
+            block.add_note("refiner: confidence aligned with next block")
+
+        if (
+            previous
+            and following
+            and previous.category == following.category == "literal"
+            and block.category == "unknown"
+            and signature.marker_density() > 0
+        ):
+            block.category = "literal"
+            block.confidence = max(block.confidence, self.settings.literal_confidence)
+            block.add_note("refiner: interpolated literal block between literal neighbours")
+@dataclass(frozen=True)
+class RefinementSummary:
+    """Aggregated view of the refined block categories."""
+
+    literal_blocks: int
+    return_blocks: int
+    control_blocks: int
+    unknown_blocks: int
+
+    def describe(self) -> str:
+        return (
+            f"literal={self.literal_blocks} return={self.return_blocks} "
+            f"control={self.control_blocks} unknown={self.unknown_blocks}"
+        )
+

--- a/mbcdisasm/analyzer/comparison.py
+++ b/mbcdisasm/analyzer/comparison.py
@@ -1,0 +1,176 @@
+"""Utilities for comparing pipeline analysis reports.
+
+Reverse engineering sessions often involve iterating on the analyser heuristics
+and checking how the classification changes across several binaries.  The helper
+functions defined in this module compute structural diffs between two
+:class:`~mbcdisasm.analyzer.report.PipelineReport` objects and highlight drifts in
+category assignments, stack deltas and block boundaries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import zip_longest
+from typing import List, Mapping, Sequence, Tuple
+
+from .instruction_profile import InstructionKind
+from .report import PipelineBlock, PipelineReport
+
+__all__ = ["BlockDiff", "CategoryDelta", "ReportDiff", "ReportComparator"]
+
+
+@dataclass(frozen=True)
+class CategoryDelta:
+    """Report category count differences between two analyses."""
+
+    category: str
+    old_count: int
+    new_count: int
+
+    def delta(self) -> int:
+        return self.new_count - self.old_count
+
+    def describe(self) -> str:
+        return f"{self.category}:{self.old_count}->{self.new_count} (Δ={self.delta():+d})"
+
+
+@dataclass(frozen=True)
+class BlockDiff:
+    """Describe how a block changed between two analysis runs."""
+
+    index: int
+    old_category: str
+    new_category: str
+    old_confidence: float
+    new_confidence: float
+    old_stack: int
+    new_stack: int
+    message: str
+
+    def describe(self) -> str:
+        return (
+            f"#{self.index} {self.old_category}->{self.new_category} "
+            f"conf {self.old_confidence:.2f}->{self.new_confidence:.2f} "
+            f"stack {self.old_stack:+d}->{self.new_stack:+d} : {self.message}"
+        )
+
+
+@dataclass(frozen=True)
+class ReportDiff:
+    """Summary of differences between two reports."""
+
+    category_changes: Tuple[BlockDiff, ...]
+    category_stats: Tuple[CategoryDelta, ...]
+    size_delta: int
+    stack_delta: int
+
+    def describe(self) -> str:
+        lines = [
+            f"blocksΔ={self.size_delta:+d}",
+            f"stackΔ={self.stack_delta:+d}",
+        ]
+        if self.category_stats:
+            cat_summary = ", ".join(delta.describe() for delta in self.category_stats)
+            lines.append(cat_summary)
+        for diff in self.category_changes:
+            lines.append(diff.describe())
+        return " | ".join(lines)
+
+
+class ReportComparator:
+    """Compare two pipeline reports and highlight differences."""
+
+    def compare(self, old: PipelineReport, new: PipelineReport) -> ReportDiff:
+        old_blocks = old.blocks
+        new_blocks = new.blocks
+        size_delta = len(new_blocks) - len(old_blocks)
+        stack_delta = (new.total_stack_change() if new else 0) - (old.total_stack_change() if old else 0)
+
+        changes: List[BlockDiff] = []
+        for index, pair in enumerate(zip_longest(old_blocks, new_blocks)):
+            old_block, new_block = pair
+            if old_block is None or new_block is None:
+                continue
+            if old_block.category == new_block.category and abs(old_block.confidence - new_block.confidence) < 1e-3:
+                continue
+            message = self._build_message(old_block, new_block)
+            changes.append(
+                BlockDiff(
+                    index=index,
+                    old_category=old_block.category,
+                    new_category=new_block.category,
+                    old_confidence=old_block.confidence,
+                    new_confidence=new_block.confidence,
+                    old_stack=old_block.stack.change,
+                    new_stack=new_block.stack.change,
+                    message=message,
+                )
+            )
+
+        category_stats = self._category_deltas(old_blocks, new_blocks)
+
+        return ReportDiff(
+            category_changes=tuple(changes),
+            category_stats=tuple(category_stats),
+            size_delta=size_delta,
+            stack_delta=stack_delta,
+        )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _build_message(self, old: PipelineBlock, new: PipelineBlock) -> str:
+        parts = []
+        if old.kind != new.kind:
+            parts.append(f"kind {old.kind.name}->{new.kind.name}")
+        if old.stack.change != new.stack.change:
+            parts.append(f"stack {old.stack.change:+d}->{new.stack.change:+d}")
+        literal_delta = self._literal_ratio(new) - self._literal_ratio(old)
+        if abs(literal_delta) > 0.05:
+            parts.append(f"literal_ratioΔ={literal_delta:+.2f}")
+        return ", ".join(parts) if parts else "classification drift"
+
+    def _literal_ratio(self, block: PipelineBlock) -> float:
+        if not block.profiles:
+            return 0.0
+        literal_like = 0
+        for profile in block.profiles:
+            if profile.kind in {
+                InstructionKind.LITERAL,
+                InstructionKind.MARKER,
+                InstructionKind.PUSH,
+                InstructionKind.ASCII_CHUNK,
+            }:
+                literal_like += 1
+        return literal_like / len(block.profiles)
+
+    def _category_deltas(
+        self, old_blocks: Sequence[PipelineBlock], new_blocks: Sequence[PipelineBlock]
+    ) -> List[CategoryDelta]:
+        old_histogram = self._category_histogram(old_blocks)
+        new_histogram = self._category_histogram(new_blocks)
+        categories = sorted(set(old_histogram) | set(new_histogram))
+        deltas: List[CategoryDelta] = []
+        for category in categories:
+            deltas.append(
+                CategoryDelta(
+                    category=category,
+                    old_count=old_histogram.get(category, 0),
+                    new_count=new_histogram.get(category, 0),
+                )
+            )
+        return deltas
+
+    def _category_histogram(self, blocks: Sequence[PipelineBlock]) -> Mapping[str, int]:
+        histogram: dict[str, int] = {}
+        for block in blocks:
+            histogram[block.category] = histogram.get(block.category, 0) + 1
+        return histogram
+
+
+def describe_diff(old: PipelineReport, new: PipelineReport) -> str:
+    """Return a textual summary describing how ``new`` differs from ``old``."""
+
+    comparator = ReportComparator()
+    diff = comparator.compare(old, new)
+    return diff.describe()

--- a/mbcdisasm/analyzer/insights.py
+++ b/mbcdisasm/analyzer/insights.py
@@ -1,0 +1,114 @@
+"""Generate human readable summaries from pipeline reports.
+
+The high level analyser exposes a detailed :class:`~mbcdisasm.analyzer.report.PipelineReport`
+object but in practice engineers often need a condensed overview when scanning
+multiple binaries.  The helpers defined here provide textual summaries and table
+renderers that highlight the dominant categories, stack usage and refinement
+metrics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from .report import PipelineBlock, PipelineReport
+from .block_refiner import RefinementSummary
+
+__all__ = ["CategoryRow", "ReportTable", "build_report_table", "format_report_table"]
+
+
+@dataclass(frozen=True)
+class CategoryRow:
+    """Representation of a single row in the report summary table."""
+
+    category: str
+    count: int
+    stack_delta: int
+    average_confidence: float
+
+    def describe(self) -> str:
+        return (
+            f"{self.category:<10} count={self.count:<3d} stackΔ={self.stack_delta:+4d} "
+            f"conf={self.average_confidence:.2f}"
+        )
+
+
+@dataclass
+class ReportTable:
+    """Structured representation of a pipeline report summary."""
+
+    rows: List[CategoryRow]
+    total_blocks: int
+    total_stack_delta: int
+    refinement: RefinementSummary | None = None
+
+    def describe(self) -> str:
+        lines = [f"blocks={self.total_blocks} stackΔ={self.total_stack_delta:+d}"]
+        for row in self.rows:
+            lines.append("  " + row.describe())
+        if self.refinement:
+            lines.append("  refinement " + self.refinement.describe())
+        return "\n".join(lines)
+
+
+def build_report_table(report: PipelineReport) -> ReportTable:
+    """Create a :class:`ReportTable` from ``report``."""
+
+    rows: List[CategoryRow] = []
+    histogram = _category_histogram(report.blocks)
+    stack_totals = _category_stack_delta(report.blocks)
+    confidence_totals = _category_confidence(report.blocks)
+
+    for category in sorted(histogram):
+        count = histogram[category]
+        stack_delta = stack_totals.get(category, 0)
+        confidence = 0.0
+        if count:
+            confidence = confidence_totals.get(category, 0.0) / count
+        rows.append(
+            CategoryRow(
+                category=category,
+                count=count,
+                stack_delta=stack_delta,
+                average_confidence=confidence,
+            )
+        )
+
+    return ReportTable(
+        rows=rows,
+        total_blocks=len(report.blocks),
+        total_stack_delta=report.total_stack_change(),
+        refinement=report.refinement,
+    )
+
+
+def format_report_table(table: ReportTable) -> str:
+    """Format ``table`` as a human readable multi-line string."""
+
+    return table.describe()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _category_histogram(blocks: Sequence[PipelineBlock]) -> dict[str, int]:
+    histogram: dict[str, int] = {}
+    for block in blocks:
+        histogram[block.category] = histogram.get(block.category, 0) + 1
+    return histogram
+
+
+def _category_stack_delta(blocks: Sequence[PipelineBlock]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for block in blocks:
+        totals[block.category] = totals.get(block.category, 0) + block.stack.change
+    return totals
+
+
+def _category_confidence(blocks: Sequence[PipelineBlock]) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    for block in blocks:
+        totals[block.category] = totals.get(block.category, 0.0) + block.confidence
+    return totals

--- a/mbcdisasm/analyzer/lexicon.py
+++ b/mbcdisasm/analyzer/lexicon.py
@@ -1,0 +1,362 @@
+"""Utility helpers for keyword based classification.
+
+The disassembler consumes a heterogeneous knowledge base that mixes English and
+Russian descriptions.  Historically the classification layer used simple
+substring checks which failed to account for Cyrillic spellings and for
+morphological variations (``literal`` vs ``literals`` vs ``литерал``).  The
+lexicon module centralises the normalisation logic and provides a registry of
+synonyms that can be shared across the analyser components.
+
+The goal of the lexicon is *not* to provide a full natural language
+understanding layer.  Instead it offers a deterministic matcher that understands
+common inflections and transliteration variants.  This keeps the implementation
+fast, easy to reason about and fully transparent to reverse engineers studying
+the emitted diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import unicodedata
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Set, Tuple
+
+__all__ = [
+    "KeywordLexicon",
+    "KeywordMatch",
+    "normalise",
+    "tokenise",
+    "default_lexicon",
+]
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+def _strip_diacritics(text: str) -> str:
+    """Return ``text`` without diacritic marks."""
+
+    decomposed = unicodedata.normalize("NFKD", text)
+    filtered = [char for char in decomposed if not unicodedata.combining(char)]
+    return unicodedata.normalize("NFKC", "".join(filtered))
+
+
+def normalise(text: str) -> str:
+    """Return a normalised representation of ``text``.
+
+    The function performs a number of lightweight transformations:
+
+    * Unicode normalisation and diacritic stripping.
+    * Lowercasing using :func:`str.casefold` which handles both ASCII and
+      Cyrillic characters.
+    * Replacement of punctuation symbols with whitespace.
+    * Collapsing multiple whitespace characters into a single space.
+
+    The end result is well suited for straightforward substring checks or for
+    tokenisation.
+    """
+
+    text = _strip_diacritics(text)
+    text = text.casefold()
+    translation_table = dict.fromkeys(map(ord, "-_,.;:!?#/"), " ")
+    text = text.translate(translation_table)
+    text = " ".join(part for part in text.split() if part)
+    return text
+
+
+def tokenise(text: str) -> Tuple[str, ...]:
+    """Split ``text`` into normalised tokens."""
+
+    if not text:
+        return tuple()
+    return tuple(normalise(text).split())
+
+
+# ---------------------------------------------------------------------------
+# Lexicon data structures
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class KeywordMatch:
+    """Represents the result of a lexicon lookup."""
+
+    label: str
+    score: float
+    evidence: Tuple[str, ...] = tuple()
+
+    def describe(self) -> str:
+        if not self.evidence:
+            return f"{self.label}={self.score:.2f}"
+        return f"{self.label}={self.score:.2f} ({', '.join(self.evidence)})"
+
+
+@dataclass
+class KeywordEntry:
+    """Stores canonical tokens and their synonyms."""
+
+    label: str
+    tokens: Set[str] = field(default_factory=set)
+
+    def add(self, *synonyms: str) -> None:
+        for synonym in synonyms:
+            if not synonym:
+                continue
+            for token in tokenise(synonym):
+                self.tokens.add(token)
+
+    def matches(self, text: str) -> bool:
+        normalised = tokenise(text)
+        return any(token in self.tokens for token in normalised)
+
+
+class KeywordLexicon:
+    """Lookup table for keyword driven classification."""
+
+    def __init__(self) -> None:
+        self._entries: Dict[str, KeywordEntry] = {}
+        self._aliases: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # registration API
+    # ------------------------------------------------------------------
+    def register(self, label: str, *synonyms: str, alias: Optional[str] = None) -> None:
+        """Add ``label`` to the lexicon with ``synonyms``.
+
+        The optional ``alias`` argument can be used to reuse the synonym set from
+        another label.  This is handy when a concept appears under two canonical
+        names (for example ``literal`` and ``const``) but should be treated as the
+        same group during classification.
+        """
+
+        label = label.strip().lower()
+        entry = self._entries.setdefault(label, KeywordEntry(label=label))
+        entry.add(*synonyms)
+        if alias:
+            self._aliases[label] = alias.strip().lower()
+
+    def extend(self, mapping: Mapping[str, Sequence[str]]) -> None:
+        for label, synonyms in mapping.items():
+            self.register(label, *synonyms)
+
+    # ------------------------------------------------------------------
+    # query API
+    # ------------------------------------------------------------------
+    def aliases_for(self, label: str) -> Tuple[str, ...]:
+        primary = self._aliases.get(label)
+        if primary:
+            return (primary,)
+        return tuple()
+
+    def entry(self, label: str) -> Optional[KeywordEntry]:
+        return self._entries.get(label)
+
+    def entries(self) -> Iterable[KeywordEntry]:
+        return tuple(self._entries.values())
+
+    def match(self, text: str, labels: Iterable[str]) -> Tuple[KeywordMatch, ...]:
+        """Return matches for ``text`` restricted to ``labels``.
+
+        The method iterates over ``labels`` and checks whether the corresponding
+        synonym set is present in ``text``.  The score is currently a simple
+        binary indicator (``1.0`` for a match) but the class is intentionally
+        designed to accommodate future weighting schemes.
+        """
+
+        matches: list[KeywordMatch] = []
+        normalised = normalise(text)
+        for label in labels:
+            entry = self.entry(label)
+            if not entry:
+                continue
+            if any(token in entry.tokens for token in normalised.split()):
+                matches.append(KeywordMatch(label=label, score=1.0, evidence=(text,)))
+                continue
+            for alias in self.aliases_for(label):
+                alias_entry = self.entry(alias)
+                if alias_entry and any(token in alias_entry.tokens for token in normalised.split()):
+                    matches.append(KeywordMatch(label=label, score=1.0, evidence=(text,)))
+                    break
+        return tuple(matches)
+
+    def detect(self, text: str) -> Tuple[KeywordMatch, ...]:
+        """Return matches for all registered labels."""
+
+        matches: list[KeywordMatch] = []
+        normalised = normalise(text)
+        for entry in self._entries.values():
+            if any(token in entry.tokens for token in normalised.split()):
+                matches.append(KeywordMatch(label=entry.label, score=1.0, evidence=(text,)))
+        return tuple(matches)
+
+
+# ---------------------------------------------------------------------------
+# Default lexicon configuration
+# ---------------------------------------------------------------------------
+
+def default_lexicon() -> KeywordLexicon:
+    """Return a :class:`KeywordLexicon` populated with common synonyms."""
+
+    lexicon = KeywordLexicon()
+    lexicon.extend(
+        {
+            "literal": [
+                "literal",
+                "literals",
+                "const",
+                "constant",
+                "constants",
+                "immediate",
+                "константа",
+                "константы",
+                "литерал",
+                "литералы",
+                "значение",
+            ],
+            "ascii": [
+                "ascii",
+                "текст",
+                "строка",
+                "string",
+                "inline",
+            ],
+            "marker": [
+                "marker",
+                "markers",
+                "маркер",
+                "маркеры",
+                "resource",
+                "ресурс",
+                "ресурсный",
+                "структурный",
+                "comment",
+                "annotation",
+            ],
+            "push": [
+                "push",
+                "stack push",
+                "загрузка",
+                "помещение",
+                "stack",
+                "помещает",
+            ],
+            "reduce": [
+                "reduce",
+                "reducer",
+                "fold",
+                "collapses",
+                "редуктор",
+                "сворачивает",
+            ],
+            "copy": [
+                "copy",
+                "duplicate",
+                "dup",
+                "копир",
+                "дублир",
+            ],
+            "indirect": [
+                "indirect",
+                "table",
+                "lookup",
+                "косвенные",
+                "таблица",
+                "индексация",
+                "slot",
+                "слот",
+            ],
+            "table": [
+                "table",
+                "таблица",
+                "табличн",
+            ],
+            "return": [
+                "return",
+                "terminator",
+                "halt",
+                "возврат",
+                "окончание",
+                "завершение",
+            ],
+            "terminator": [
+                "terminator",
+                "halt",
+                "stop",
+                "конец",
+                "завершение",
+            ],
+            "call": [
+                "call",
+                "invoke",
+                "вызов",
+                "tailcall",
+            ],
+            "test": [
+                "test",
+                "branch",
+                "условие",
+                "проверка",
+            ],
+            "arithmetic": [
+                "arith",
+                "math",
+                "матем",
+                "арифм",
+            ],
+            "logical": [
+                "logic",
+                "boolean",
+                "логик",
+                "булев",
+            ],
+            "bitwise": [
+                "bit",
+                "бит",
+                "разря",
+            ],
+            "stack_teardown": [
+                "teardown",
+                "drop",
+                "clear",
+                "pop",
+                "tears",
+                "сбрасыва",
+                "разбор",
+                "снимает",
+            ],
+            "meta": [
+                "meta",
+                "helper",
+                "служеб",
+                "вспомог",
+                "описат",
+            ],
+        }
+    )
+
+    # Aliases allow us to reuse synonym sets without duplicating data.
+    lexicon.register("const", alias="literal")
+    lexicon.register("literal_marker", alias="marker")
+
+    return lexicon
+
+
+# Shared singleton used by the analyser.  The singleton makes it trivial to
+# plug the lexicon into existing helper functions without threading additional
+# configuration objects through every call site.
+DEFAULT_LEXICON = default_lexicon()
+
+
+def lookup_keywords(text: Optional[str], *labels: str) -> Tuple[KeywordMatch, ...]:
+    """Utility wrapper that looks up ``labels`` within ``text``."""
+
+    if not text:
+        return tuple()
+    return DEFAULT_LEXICON.match(text, labels)
+
+
+def has_keyword(text: Optional[str], label: str) -> bool:
+    """Return ``True`` if ``label`` is present in ``text``."""
+
+    if not text:
+        return False
+    matches = lookup_keywords(text, label)
+    return any(match.label == label for match in matches)

--- a/mbcdisasm/analyzer/report.py
+++ b/mbcdisasm/analyzer/report.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple
 
 from .instruction_profile import InstructionKind, InstructionProfile, dominant_kind
 from .patterns import PatternMatch
 from .stack import StackSummary
 from .stats import PipelineStatistics
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .block_refiner import RefinementSummary
 
 
 @dataclass
@@ -70,6 +73,7 @@ class PipelineReport:
     blocks: Tuple[PipelineBlock, ...]
     warnings: Tuple[str, ...] = tuple()
     statistics: Optional[PipelineStatistics] = None
+    refinement: Optional["RefinementSummary"] = None
 
     def describe(self) -> str:
         lines = ["Pipeline analysis report:"]
@@ -81,6 +85,8 @@ class PipelineReport:
                 lines.append("  - " + warning)
         if self.statistics:
             lines.append("Statistics: " + self.statistics.describe())
+        if self.refinement:
+            lines.append("Refinement: " + self.refinement.describe())
         return "\n".join(lines)
 
     def filter_by_category(self, category: str) -> Tuple[PipelineBlock, ...]:
@@ -91,7 +97,7 @@ class PipelineReport:
 
     @classmethod
     def empty(cls) -> "PipelineReport":
-        return cls(blocks=tuple(), warnings=tuple(), statistics=None)
+        return cls(blocks=tuple(), warnings=tuple(), statistics=None, refinement=None)
 
 
 def build_block(

--- a/mbcdisasm/disassembler.py
+++ b/mbcdisasm/disassembler.py
@@ -65,6 +65,8 @@ class Disassembler:
                     dominant=dominant,
                 )
             )
+        if report and report.refinement:
+            lines.append("; pipeline refinement: " + report.refinement.describe())
         if report and report.warnings:
             lines.append("; pipeline warnings:")
             for warning in report.warnings:


### PR DESCRIPTION
## Summary
- add a multilingual keyword lexicon and extend instruction classification to recognise marker opcodes reliably
- introduce a block refinement pass plus supporting comparison/insight utilities to stabilise pipeline categories and reporting
- expand heuristic and pattern detection to cover marker-heavy literal sequences and propagate refined statistics to the CLI output

## Testing
- python -m compileall mbcdisasm
- python mbc_disasm.py mbc/_char.adb mbc/_char.mbc
- python mbc_disasm.py mbc/_player.adb mbc/_player.mbc --max-instr 200

------
https://chatgpt.com/codex/tasks/task_e_68dbe023098c832f9836ce6425aaf0d2