### PR TITLE
Improve analyzer recognition for literal-heavy scripts

### DIFF
--- a/mbcdisasm/analyzer/patterns.py
+++ b/mbcdisasm/analyzer/patterns.py
@@ -138,6 +138,9 @@ def default_patterns() -> PatternRegistry:
     registry = PatternRegistry()
     registry.extend(
         [
+            literal_run_pattern(),
+            ascii_run_pattern(),
+            marker_run_pattern(),
             literal_pipeline(),
             ascii_pipeline(),
             reduce_pipeline(),
@@ -147,6 +150,75 @@ def default_patterns() -> PatternRegistry:
         ]
     )
     return registry
+
+
+def literal_run_pattern() -> PipelinePattern:
+    """Return a pattern that matches dense literal pushes."""
+
+    tokens = tuple(
+        PatternToken(
+            kinds=(
+                InstructionKind.LITERAL,
+                InstructionKind.ASCII_CHUNK,
+                InstructionKind.PUSH,
+            ),
+            min_delta=0,
+            max_delta=1,
+            description="literal burst",
+        )
+        for _ in range(4)
+    )
+    return PipelinePattern(
+        name="literal_bulk",
+        category="literal",
+        tokens=tokens,
+        allow_extra=True,
+        description="Sequence of literal pushes (≥4 instructions)",
+    )
+
+
+def ascii_run_pattern() -> PipelinePattern:
+    """Return a pattern that matches clusters of ASCII chunks."""
+
+    tokens = tuple(
+        PatternToken(
+            kinds=(InstructionKind.ASCII_CHUNK,),
+            min_delta=0,
+            max_delta=0,
+            description="ascii chunk",
+        )
+        for _ in range(3)
+    )
+    return PipelinePattern(
+        name="ascii_stream",
+        category="literal",
+        tokens=tokens,
+        allow_extra=True,
+        stack_change=0,
+        description="Run of inline ASCII words",
+    )
+
+
+def marker_run_pattern() -> PipelinePattern:
+    """Return a pattern matching stack-neutral literal markers."""
+
+    tokens = tuple(
+        PatternToken(
+            kinds=(InstructionKind.LITERAL,),
+            min_delta=0,
+            max_delta=0,
+            description="literal marker",
+        )
+        for _ in range(3)
+    )
+    return PipelinePattern(
+        name="marker_cluster",
+        category="literal",
+        tokens=tokens,
+        allow_extra=True,
+        stack_change=0,
+        description="Cluster of literal markers",
+    )
 
 
 def literal_pipeline() -> PipelinePattern:

--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -1,0 +1,202 @@
+"""Heuristic pipeline signatures.
+
+The pattern matcher in :mod:`mbcdisasm.analyzer.patterns` focuses on strict
+instruction templates that can be expressed as deterministic finite automata.
+While extremely fast, these templates struggle with the sprawling literal
+sections present in scripts such as ``_char`` where hundreds of consecutive
+instructions merely shuttle data around.  The :class:`SignatureDetector`
+defined in this module complements the automaton-based approach with a set of
+loosely defined *signatures*.  Each signature encodes a higher level behaviour
+observed during manual reverse engineering sessions – for example "a run of
+ASCII words" or "table slot initialisation" – and can match even when the
+exact instruction mix varies slightly between occurrences.
+
+The detector is intentionally opinionated and biased towards literal-heavy
+pipelines because those are the hardest to classify without manual hints.  The
+implementation is verbose; rich docstrings and descriptive variable names make
+the heuristics easier to audit and tweak during future reversing sessions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple
+
+from .instruction_profile import InstructionKind, InstructionProfile
+from .stack import StackSummary
+
+
+LiteralLike = {
+    InstructionKind.LITERAL,
+    InstructionKind.ASCII_CHUNK,
+    InstructionKind.PUSH,
+}
+
+
+@dataclass(frozen=True)
+class SignatureMatch:
+    """Result of a successful signature detection."""
+
+    name: str
+    category: str
+    confidence: float
+    notes: Tuple[str, ...] = tuple()
+
+
+class SignatureRule:
+    """Base class for heuristic signature rules."""
+
+    name: str = "signature"
+    category: str = "unknown"
+    base_confidence: float = 0.55
+
+    def match(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        raise NotImplementedError
+
+
+class AsciiRunSignature(SignatureRule):
+    """Match blocks composed purely of ASCII chunk instructions."""
+
+    name = "ascii_run"
+    category = "literal"
+    base_confidence = 0.68
+
+    def match(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        if len(profiles) < 3:
+            return None
+        if not all(profile.kind is InstructionKind.ASCII_CHUNK for profile in profiles):
+            return None
+        notes = (
+            f"ascii_run length={len(profiles)}",
+            f"stackΔ={stack.change:+d}",
+        )
+        return SignatureMatch(self.name, self.category, self.base_confidence, notes)
+
+
+class LiteralRunSignature(SignatureRule):
+    """Match blocks that contain a dense sequence of literal pushes."""
+
+    name = "literal_run"
+    category = "literal"
+    base_confidence = 0.62
+
+    def match(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        if len(profiles) < 4:
+            return None
+        literal_like = sum(1 for profile in profiles if profile.kind in LiteralLike)
+        density = literal_like / len(profiles)
+        if density < 0.7:
+            return None
+        notes = (
+            f"literal_density={density:.2f}",
+            f"stackΔ={stack.change:+d}",
+        )
+        confidence = self.base_confidence + 0.05 * (density - 0.7)
+        return SignatureMatch(self.name, self.category, confidence, notes)
+
+
+class MarkerRunSignature(SignatureRule):
+    """Detect clusters of literal marker instructions."""
+
+    name = "marker_run"
+    category = "literal"
+    base_confidence = 0.57
+
+    def match(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        if len(profiles) < 3:
+            return None
+        if not all(profile.mnemonic == "literal_marker" for profile in profiles):
+            return None
+        notes = (
+            f"marker_cluster={len(profiles)}",
+            f"stackΔ={stack.change:+d}",
+        )
+        return SignatureMatch(self.name, self.category, self.base_confidence, notes)
+
+
+class TableStoreSignature(SignatureRule):
+    """Recognise the table slot initialisation pattern used in ``_char``."""
+
+    name = "table_store"
+    category = "literal"
+    base_confidence = 0.65
+
+    def match(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        if len(profiles) < 5:
+            return None
+        labels = [profile.label for profile in profiles]
+        if labels[0] != "66:75":
+            return None
+        if "10:0E" not in labels[:3]:
+            return None
+        if not any(profile.kind is InstructionKind.PUSH for profile in profiles):
+            return None
+        notes = (
+            "detected table slot flush",
+            f"operands={[profile.operand for profile in profiles[:4]]}",
+        )
+        confidence = self.base_confidence
+        if stack.change >= 0:
+            confidence += 0.05
+        return SignatureMatch(self.name, self.category, confidence, notes)
+
+
+class IndirectFetchSignature(SignatureRule):
+    """Match the indirect access setup commonly found around character tables."""
+
+    name = "indirect_fetch"
+    category = "indirect"
+    base_confidence = 0.66
+
+    def match(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        if len(profiles) < 4:
+            return None
+        if profiles[-1].kind is not InstructionKind.INDIRECT:
+            return None
+        if not any(profile.label == "75:30" for profile in profiles):
+            return None
+        if not any(profile.kind in LiteralLike for profile in profiles):
+            return None
+        notes = (
+            "indirect_fetch detected",
+            f"stackΔ={stack.change:+d}",
+        )
+        return SignatureMatch(self.name, self.category, self.base_confidence, notes)
+
+
+class SignatureDetector:
+    """Run a collection of :class:`SignatureRule` objects on a block."""
+
+    def __init__(self, rules: Optional[Iterable[SignatureRule]] = None) -> None:
+        self.rules: Tuple[SignatureRule, ...] = tuple(rules or self._default_rules())
+
+    @staticmethod
+    def _default_rules() -> Tuple[SignatureRule, ...]:
+        return (
+            AsciiRunSignature(),
+            TableStoreSignature(),
+            IndirectFetchSignature(),
+            LiteralRunSignature(),
+            MarkerRunSignature(),
+        )
+
+    def detect(
+        self, profiles: Sequence[InstructionProfile], stack: StackSummary
+    ) -> Optional[SignatureMatch]:
+        for rule in self.rules:
+            match = rule.match(profiles, stack)
+            if match is not None:
+                return match
+        return None

--- a/mbcdisasm/analyzer/stats.py
+++ b/mbcdisasm/analyzer/stats.py
@@ -73,6 +73,16 @@ class PipelineStatistics:
             return None
         return max(self.categories.items(), key=lambda item: item[1].count)[0]
 
+    def recognised_ratio(self) -> float:
+        """Return the fraction of blocks assigned a non-unknown category."""
+
+        if not self.block_count:
+            return 0.0
+        unknown = self.categories.get("unknown")
+        unknown_count = unknown.count if unknown else 0
+        recognised = self.block_count - unknown_count
+        return recognised / self.block_count
+
     def describe(self) -> str:
         pieces = [f"blocks={self.block_count}", f"instr={self.instruction_count}", f"stackΔ={self.total_stack_delta:+d}"]
         for category, stats in self.categories.items():

--- a/tests/test_char_analysis.py
+++ b/tests/test_char_analysis.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from mbcdisasm import KnowledgeBase, MbcContainer
+from mbcdisasm.analyzer import PipelineAnalyzer
+from mbcdisasm.instruction import read_instructions
+
+
+def test_char_script_recognition_ratio():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    analyzer = PipelineAnalyzer(knowledge)
+    container = MbcContainer.load(Path("mbc/_char.mbc"), Path("mbc/_char.adb"))
+
+    total_blocks = 0
+    recognised = 0
+
+    for segment in container.segments():
+        instructions, _ = read_instructions(segment.data, segment.start)
+        report = analyzer.analyse_segment(instructions)
+        for block in report.blocks:
+            total_blocks += 1
+            if block.category != "unknown":
+                recognised += 1
+
+    assert total_blocks > 0
+    ratio = recognised / total_blocks
+    assert ratio >= 0.5

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from mbcdisasm import KnowledgeBase
+
+
+def test_wildcard_lookup_for_tailcall():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    info = knowledge.lookup("29:10")
+    assert info is not None
+    assert info.control_flow and "call" in info.control_flow.lower()
+
+
+def test_wildcard_lookup_for_call_helpers():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    info = knowledge.lookup("16:84")
+    assert info is not None
+    assert info.control_flow and "call" in info.control_flow.lower()

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from mbcdisasm import KnowledgeBase
+from mbcdisasm.analyzer.instruction_profile import (
+    InstructionKind,
+    InstructionProfile,
+    looks_like_ascii_chunk,
+)
+from mbcdisasm.analyzer.signatures import SignatureDetector
+from mbcdisasm.analyzer.stack import StackTracker
+from mbcdisasm.instruction import InstructionWord
+
+
+def make_word(opcode: int, mode: int, operand: int = 0, offset: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def profiles_from_words(words, knowledge):
+    profiles = [InstructionProfile.from_word(word, knowledge) for word in words]
+    stack = StackTracker()
+    summary = stack.run(profiles)
+    return profiles, summary
+
+
+def test_ascii_detection_marks_inline_chunk():
+    knowledge = KnowledgeBase({})
+    word = InstructionWord(0, int.from_bytes(b"test", "big"))
+    assert looks_like_ascii_chunk(word)
+    profile = InstructionProfile.from_word(word, knowledge)
+    assert profile.mnemonic == "inline_ascii_chunk"
+    assert profile.kind is InstructionKind.ASCII_CHUNK
+    assert profile.traits.get("heuristic")
+
+
+def test_signature_detector_matches_ascii_run():
+    knowledge = KnowledgeBase({})
+    words = [
+        InstructionWord(i * 4, int.from_bytes(text.encode("ascii"), "big"))
+        for i, text in enumerate(["char", "name", "data"])
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "ascii_run"
+    assert match.category == "literal"
+
+
+def test_signature_detector_matches_literal_run():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    words = [make_word(0x00, 0x00, operand, idx * 4) for idx, operand in enumerate([0x10, 0x11, 0x12, 0x13, 0x14])]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name in {"literal_run", "literal_bulk"}
+
+
+def test_signature_detector_matches_table_store_pattern():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    words = [
+        make_word(0x66, 0x75, 0x3029, 0),
+        make_word(0x10, 0x0E, 0x41E1, 4),
+        make_word(0x03, 0x00, 0x0006, 8),
+        make_word(0x00, 0x6C, 0x11F4, 12),
+        make_word(0x00, 0x00, 0x0090, 16),
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "table_store"


### PR DESCRIPTION
## Summary
- extend the opcode knowledge loader with wildcard support so families like `29:*` resolve automatically
- add heuristic ASCII detection, literal run patterns, and a signature-based detector to classify literal and table-building blocks
- surface recognition ratio information in the disassembler output and add focused tests, including an integration check on `_char`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe5b42a1c832f81389c8c38439120