### PR TITLE
Improve literal heuristics for _char analysis

### DIFF
--- a/mbcdisasm/knowledge.py
+++ b/mbcdisasm/knowledge.py
@@ -225,17 +225,20 @@ def _normalize_label(label: str) -> Optional[str]:
 def _extract_opcode(label: str) -> Optional[int]:
     """Return the opcode component encoded in ``label``.
 
-    The helper accepts labels in the canonical ``"AA:BB"`` form and returns the
-    integer value of the first component.  Invalid tokens yield ``None`` which
-    allows callers to fall back to other lookup strategies without having to
-    repeat the parsing logic.
+    Runtime lookups operate on canonicalised labels emitted by
+    :meth:`InstructionWord.label`.  Those strings use fixed width hexadecimal
+    components (``"AA:BB"``) regardless of how the opcode was described in the
+    manual annotations.  Relying on :func:`_parse_component` would treat values
+    such as ``"10"`` as decimal numbers which breaks wildcard resolution for
+    opcode ``0x10``.  To avoid this ambiguity the extractor interprets the
+    canonical representation as hexadecimal directly.
     """
 
     if ":" not in label:
         return None
     opcode_text, _ = label.split(":", 1)
     try:
-        opcode = _parse_component(opcode_text)
+        opcode = int(opcode_text, 16)
     except ValueError:
         return None
     if not (0 <= opcode <= 0xFF):

--- a/tests/test_char_analysis.py
+++ b/tests/test_char_analysis.py
@@ -12,6 +12,7 @@ def test_char_script_recognition_ratio():
 
     total_blocks = 0
     recognised = 0
+    unknown_instructions = 0
 
     for segment in container.segments():
         instructions, _ = read_instructions(segment.data, segment.start)
@@ -20,7 +21,16 @@ def test_char_script_recognition_ratio():
             total_blocks += 1
             if block.category != "unknown":
                 recognised += 1
+            unknown_instructions += sum(1 for profile in block.profiles if profile.kind.name == "UNKNOWN")
 
     assert total_blocks > 0
     ratio = recognised / total_blocks
-    assert ratio >= 0.5
+    assert ratio == 1.0
+    assert unknown_instructions == 0
+
+
+def test_call_helper_wildcard_resolution():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    info = knowledge.lookup("10:84")
+    assert info is not None
+    assert (info.control_flow or "").lower().startswith("call")


### PR DESCRIPTION
## Summary
- expand the instruction kind classifier with a literal heuristic that recognises ASCII-heavy and marker-like words
- ensure knowledge lookups parse canonical hex labels and add a regression test for call helper wildcards
- tighten the _char analysis test to require full block recognition and zero unknown instructions

## Testing
- pytest tests/test_char_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2d4dd4bc832fbc9f3d4ef54e1884