### PR TITLE
Improve _char classification heuristics

### DIFF
--- a/mbcdisasm/analyzer/pipeline.py
+++ b/mbcdisasm/analyzer/pipeline.py
@@ -172,6 +172,9 @@ class PipelineAnalyzer:
         elif dominant in {InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP}:
             category = "indirect"
             confidence = 0.5
+        elif dominant is InstructionKind.META:
+            category = "literal"
+            confidence = 0.45
 
         feature_map = heuristics.feature_map()
 


### PR DESCRIPTION
## Summary
- Expand instruction profiling heuristics with relaxed ASCII detection and a comprehensive opcode fallback map so that _char instructions are classified as literals, calls or indirect operations instead of UNKNOWN.
- Treat META-dominant analyzer blocks as literal pipelines and make wildcard lookups prefer decimal opcode families to keep historical annotations available.

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dc4131745c832fa50f3646150c5694