### PR TITLE
Improve opcode classification and pipeline heuristics

### DIFF
--- a/mbcdisasm/analyzer/pipeline.py
+++ b/mbcdisasm/analyzer/pipeline.py
@@ -172,6 +172,9 @@ class PipelineAnalyzer:
         elif dominant in {InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP}:
             category = "indirect"
             confidence = 0.5
+        elif dominant is InstructionKind.META:
+            category = "compute"
+            confidence = 0.45
 
         feature_map = heuristics.feature_map()
 
@@ -182,6 +185,10 @@ class PipelineAnalyzer:
         if "call_helper" in feature_map:
             category = "call"
             confidence = max(confidence, 0.65)
+
+        if "literal_chain" in feature_map and category in {"unknown", "compute"}:
+            category = "literal"
+            confidence = max(confidence, 0.5)
 
         if "return_sequence" in feature_map or "stack_teardown" in feature_map:
             category = "return"


### PR DESCRIPTION
## Summary
- extend the knowledge lookup to interpret decimal and hexadecimal opcode labels so wildcard metadata applies to the disassembler output
- enhance instruction classification by adding keyword recognisers (including Russian synonyms) and opcode heuristics, eliminating UNKNOWN kinds in the _char script
- refine pipeline block categorisation so meta-heavy blocks map to literal/call/compute categories based on heuristic features

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4131745c832fa50f3646150c5694