### PR TITLE
Normalize tailcall ASCII wrappers and collapse marker runs

### DIFF
--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -159,9 +159,10 @@ def test_signature_detector_matches_tailcall_return_marker():
     words = [
         make_word(0x00, 0x52, 0x0000, 0),
         make_word(0x29, 0x10, 0x0001, 4),
-        make_word(0x30, 0x69, 0x0000, 8),
-        make_word(0x00, 0x00, 0x6704, 12),
-        make_word(0x00, 0x00, 0x0067, 16),
+        InstructionWord(8, int.from_bytes(b"tail", "big")),
+        make_word(0x30, 0x69, 0x0000, 12),
+        make_word(0x00, 0x00, 0x6704, 16),
+        make_word(0x00, 0x00, 0x0067, 20),
     ]
     profiles, summary = profiles_from_words(words, knowledge)
     detector = SignatureDetector()


### PR DESCRIPTION
## Summary
- collapse literal marker runs before DFA matching so tailcall/return wrappers stay in one block
- relax the tailcall_return_marker signature to allow harmless ASCII and literal fillers between the dispatch and return
- add regression tests covering event normalisation, segmentation, and ASCII tailcall markers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df14297648832f9f3aaf7e0c0ebfce