### PR TITLE
Handle marker-stretched ASCII tailcall wrappers

### DIFF
--- a/mbcdisasm/analyzer/stack.py
+++ b/mbcdisasm/analyzer/stack.py
@@ -30,6 +30,8 @@ class StackEvent:
     depth_before: int
     depth_after: int
     uncertain: bool = False
+    marker_run: bool = False
+    span: int = 1
 
     def describe(self) -> str:
         return (


### PR DESCRIPTION
## Summary
- coalesce literal marker runs into pseudo-events so the DFA recognises tailcall blocks that include ASCII marker stretches
- relax tailcall return signatures to skip inline ASCII quartets and marker noise when searching for the terminating return

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df14297648832f9f3aaf7e0c0ebfce