### PR TITLE
Normalize tailcall ASCII wrapper handling

### DIFF
--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -872,8 +872,11 @@ class TailcallAsciiWrapperSignature(SignatureRule):
         if ascii_after == 0:
             return None
 
-        branch_after = any(profile.kind is InstructionKind.BRANCH for profile in profiles[tail_idx + 1 :])
-        if not branch_after:
+        control_after = any(
+            profile.kind in {InstructionKind.BRANCH, InstructionKind.RETURN, InstructionKind.TERMINATOR}
+            for profile in profiles[tail_idx + 1 :]
+        )
+        if not control_after:
             return None
 
         literal_prefix = sum(1 for profile in profiles[:tail_idx] if is_literal_like(profile))


### PR DESCRIPTION
## Summary
- allow the pipeline analyzer to stretch tailcall spans across inline ASCII padding so the dispatcher and return stay in one block
- relax the tailcall ASCII wrapper signature to tolerate return instructions after the literal anchors
- add a regression test that covers a tailcall with inline ASCII data merging into a single classified block

## Testing
- pytest tests/test_analyzer.py::test_tailcall_ascii_wrapper_merges_into_single_block
- pytest tests/test_signatures.py::test_signature_detector_matches_tailcall_ascii_wrapper

------
https://chatgpt.com/codex/tasks/task_e_68df14297648832f9f3aaf7e0c0ebfce