### PR TITLE
Add guarded return pipeline patterns

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -88,6 +88,23 @@ def test_return_pipeline_detection():
     assert report.total_stack_change() <= 0
 
 
+def test_guarded_return_pipeline_detection():
+    analyzer = PipelineAnalyzer(build_knowledge())
+    instructions = [
+        make_word(0, 0x30),
+        make_word(4, 0x10),
+        make_word(8, 0x12),
+        make_word(12, 0x11),
+        make_word(16, 0x31),
+    ]
+    report = analyzer.analyse_segment(instructions)
+    assert len(report.blocks) == 1
+    block = report.blocks[0]
+    assert block.category == "return"
+    assert block.pattern is not None
+    assert block.pattern.pattern.name == "guarded_return"
+
+
 class _DummyContainer:
     def __init__(self, segment: Segment) -> None:
         self._segment = segment


### PR DESCRIPTION
## Summary
- introduce a guarded_return pipeline pattern (with common prep variants) so branch+return chains collapse into a single block
- register the new pattern family with the DFA to reduce low-confidence BRANCH/RETURN fragments
- cover the behaviour with a unit test that exercises a guarded return sequence including prep opcodes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1843772c832f827b409759e90985