### PR TITLE
Add typed stack tracking for indirect access heuristics

### DIFF
--- a/mbcdisasm/analyzer/pipeline.py
+++ b/mbcdisasm/analyzer/pipeline.py
@@ -73,7 +73,17 @@ class PipelineAnalyzer:
 
     def _compute_events(self, profiles: Sequence[InstructionProfile]) -> Tuple[StackEvent, ...]:
         tracker = StackTracker()
-        events = [tracker.process(profile) for profile in profiles]
+        events: List[StackEvent] = []
+        total = len(profiles)
+        for idx, profile in enumerate(profiles):
+            following: Optional[InstructionProfile] = None
+            for lookahead in range(idx + 1, total):
+                candidate = profiles[lookahead]
+                if candidate.mnemonic == "literal_marker":
+                    continue
+                following = candidate
+                break
+            events.append(tracker.process(profile, following=following))
         return tuple(events)
 
     def _segment_into_blocks(


### PR DESCRIPTION
## Summary
- extend the stack tracker with lightweight value typing, marker handling and richer stack events
- add heuristics that split indirect access helpers into load/store modes and adjust stack deltas accordingly
- update pipeline event collection to provide lookahead context while skipping literal markers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1a8a7508832f9e88b2b938c7477e