### PR TITLE
Add typed stack tracking for indirect access

### DIFF
--- a/mbcdisasm/analyzer/patterns.py
+++ b/mbcdisasm/analyzer/patterns.py
@@ -31,9 +31,9 @@ class PatternToken:
     def matches(self, event: StackEvent) -> bool:
         """Return ``True`` if ``event`` satisfies this token."""
 
-        if not self.allow_unknown and event.profile.kind is InstructionKind.UNKNOWN:
+        if not self.allow_unknown and event.kind is InstructionKind.UNKNOWN:
             return False
-        if self.kinds and event.profile.kind not in self.kinds:
+        if self.kinds and event.kind not in self.kinds:
             return False
         if event.delta < self.min_delta or event.delta > self.max_delta:
             return False
@@ -77,7 +77,7 @@ class PipelinePattern:
         score = 1.0
         if any(event.uncertain for event in events):
             score *= 0.85
-        if any(event.profile.kind is InstructionKind.UNKNOWN for event in events):
+        if any(event.kind is InstructionKind.UNKNOWN for event in events):
             score *= 0.5
 
         return PatternMatch(pattern=self, events=tuple(events), score=score)
@@ -440,7 +440,12 @@ def indirect_load_pipeline() -> PipelinePattern:
             description="key push",
         ),
         PatternToken(
-            kinds=(InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP),
+            kinds=(
+                InstructionKind.INDIRECT,
+                InstructionKind.INDIRECT_LOAD,
+                InstructionKind.INDIRECT_STORE,
+                InstructionKind.TABLE_LOOKUP,
+            ),
             min_delta=-1,
             max_delta=0,
             description="indirect read",

--- a/mbcdisasm/analyzer/pipeline.py
+++ b/mbcdisasm/analyzer/pipeline.py
@@ -73,8 +73,7 @@ class PipelineAnalyzer:
 
     def _compute_events(self, profiles: Sequence[InstructionProfile]) -> Tuple[StackEvent, ...]:
         tracker = StackTracker()
-        events = [tracker.process(profile) for profile in profiles]
-        return tuple(events)
+        return tracker.process_sequence(profiles)
 
     def _segment_into_blocks(
         self,
@@ -169,7 +168,12 @@ class PipelineAnalyzer:
         elif dominant is InstructionKind.TEST:
             category = "test"
             confidence = 0.5
-        elif dominant in {InstructionKind.INDIRECT, InstructionKind.TABLE_LOOKUP}:
+        elif dominant in {
+            InstructionKind.INDIRECT,
+            InstructionKind.INDIRECT_LOAD,
+            InstructionKind.INDIRECT_STORE,
+            InstructionKind.TABLE_LOOKUP,
+        }:
             category = "indirect"
             confidence = 0.5
 

--- a/tests/test_stack_tracker.py
+++ b/tests/test_stack_tracker.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from mbcdisasm import KnowledgeBase
+from mbcdisasm.analyzer.instruction_profile import InstructionKind, InstructionProfile
+from mbcdisasm.analyzer.stack import StackTracker, StackValueType
+from mbcdisasm.instruction import InstructionWord
+
+
+def make_word(opcode: int, mode: int, operand: int = 0, offset: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def load_profiles(words):
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    return [InstructionProfile.from_word(word, knowledge) for word in words]
+
+
+def test_literal_marker_is_stack_neutral():
+    words = [
+        make_word(0x00, 0x26, 0x0000, 0),  # literal_marker according to knowledge
+        make_word(0x00, 0x00, 0x0001, 4),
+    ]
+    profiles = load_profiles(words)
+    tracker = StackTracker()
+    events = tracker.process_sequence(profiles)
+
+    marker_event = events[0]
+    literal_event = events[1]
+
+    assert marker_event.delta == 0
+    assert marker_event.pushed_types == (StackValueType.MARKER,)
+    assert literal_event.delta > 0
+    assert literal_event.depth_after == marker_event.depth_after + literal_event.delta
+
+
+def test_indirect_access_load_variant():
+    words = [
+        make_word(0x02, 0x00, 0x0000, 0),  # stack push helper
+        make_word(0x69, 0x10, 0x0000, 4),  # indirect access (load)
+    ]
+    profiles = load_profiles(words)
+    tracker = StackTracker()
+    events = tracker.process_sequence(profiles)
+
+    indirect_event = events[-1]
+    assert indirect_event.kind is InstructionKind.INDIRECT_LOAD
+    assert indirect_event.delta == 1
+    assert indirect_event.pushed_types == (StackValueType.NUMBER,)
+
+
+def test_indirect_access_store_variant_detects_cleanup():
+    words = [
+        make_word(0x02, 0x00, 0x0000, 0),
+        make_word(0x69, 0x10, 0x0000, 4),
+        make_word(0x01, 0xF0, 0x0000, 8),  # stack teardown helper
+    ]
+    profiles = load_profiles(words)
+    tracker = StackTracker()
+    events = tracker.process_sequence(profiles)
+
+    indirect_event = events[1]
+    assert indirect_event.kind is InstructionKind.INDIRECT_STORE
+    assert indirect_event.delta == 0
+    assert indirect_event.pushed_types == tuple()
+    assert StackValueType.SLOT in indirect_event.popped_types


### PR DESCRIPTION
## Summary
- add stack value typing to the tracker, splitting indirect access events into load/store variants and propagating contextual stack hints
- treat literal markers as stack-neutral and adjust instruction classification so indirect opcodes are recognised reliably
- update pipeline pattern matching to use the new event kinds and add focused regression tests for the tracker heuristics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1a8a7508832f9e88b2b938c7477e