### PR TITLE
Improve pipeline matching around marker clusters

### DIFF
--- a/mbcdisasm/analyzer/dfa.py
+++ b/mbcdisasm/analyzer/dfa.py
@@ -103,6 +103,9 @@ class DeterministicAutomaton:
                     # allow extra instructions until a control boundary is hit
                     extra_end = end
                     while extra_end < len(events):
+                        candidate = events[extra_end]
+                        if candidate.profile.is_control():
+                            break
                         extended = events[start:extra_end + 1]
                         extended_match = pattern.match(extended)
                         if extended_match is None:


### PR DESCRIPTION
## Summary
- allow pipeline patterns with extras to skip literal marker padding and flag guarded returns as extendable
- stop DFA pattern growth on control instructions and normalise marker runs before matching
- let block segmentation look for matches in a wider soft window before falling back to heuristic spans

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1f005b20832f9c1731deea793a8b