### PR TITLE
Improve marker-aware pipeline segmentation

### DIFF
--- a/mbcdisasm/analyzer/dfa.py
+++ b/mbcdisasm/analyzer/dfa.py
@@ -103,7 +103,10 @@ class DeterministicAutomaton:
                     # allow extra instructions until a control boundary is hit
                     extra_end = end
                     while extra_end < len(events):
-                        extended = events[start:extra_end + 1]
+                        next_event = events[extra_end]
+                        if next_event.profile.is_control():
+                            break
+                        extended = events[start : extra_end + 1]
                         extended_match = pattern.match(extended)
                         if extended_match is None:
                             break


### PR DESCRIPTION
## Summary
- cluster literal marker runs before segmentation and relax fallback spans to keep 4–9 instruction blocks
- allow key patterns to absorb marker extras and stop DFA growth at control boundaries to stabilise return detection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1f005b20832f9c1731deea793a8b