### PR TITLE
Improve marker-aware pipeline segmentation

### DIFF
--- a/mbcdisasm/analyzer/dfa.py
+++ b/mbcdisasm/analyzer/dfa.py
@@ -100,10 +100,12 @@ class DeterministicAutomaton:
                 if not pattern.allow_extra and len(slice_events) != len(pattern.tokens):
                     yield AutomatonMatch(pattern_index=pattern_index, start=start, end=end, score=match.score)
                 else:
-                    # allow extra instructions until a control boundary is hit
                     extra_end = end
                     while extra_end < len(events):
-                        extended = events[start:extra_end + 1]
+                        next_event = events[extra_end]
+                        if next_event.profile.is_control():
+                            break
+                        extended = events[start : extra_end + 1]
                         extended_match = pattern.match(extended)
                         if extended_match is None:
                             break


### PR DESCRIPTION
## Summary
- cluster literal-marker events before segmentation and extend the soft window so blocks prefer 4-9 instruction matches
- allow key patterns to accept neutral marker padding and stop DFA extensions at control-flow boundaries for cleaner matches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df1f005b20832f9c1731deea793a8b