### PR TITLE
Add macro normalizer for canonical instruction signatures

### DIFF
--- a/mbcdisasm/analyzer/normalizer.py
+++ b/mbcdisasm/analyzer/normalizer.py
@@ -1,0 +1,275 @@
+"""Instruction macro normalisation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+from .instruction_profile import InstructionKind, InstructionProfile
+
+
+LiteralLikeKinds = {
+    InstructionKind.LITERAL,
+    InstructionKind.ASCII_CHUNK,
+    InstructionKind.PUSH,
+}
+
+
+@dataclass(frozen=True)
+class MacroSignature:
+    """Description of a macro match covering a slice of profiles."""
+
+    name: str
+    kind: InstructionKind
+    category: str
+    start: int
+    end: int
+    extra: Optional[Mapping[str, object]] = None
+
+    @property
+    def span(self) -> int:
+        return max(1, self.end - self.start)
+
+
+class MacroNormalizer:
+    """Collapse frequently occurring instruction forms into macro operations."""
+
+    def apply(self, profiles: Sequence[InstructionProfile]) -> None:
+        idx = 0
+        total = len(profiles)
+        while idx < total:
+            match = (
+                self._match_tail_dispatch(profiles, idx)
+                or self._match_frame_return(profiles, idx)
+                or self._match_literal_reduce(profiles, idx)
+                or self._match_predicate(profiles, idx)
+                or self._match_indirect_access(profiles, idx)
+            )
+            if match is None:
+                idx += 1
+                continue
+
+            self._apply_match(profiles, match)
+            idx = match.end
+
+    # ------------------------------------------------------------------
+    # matchers
+    # ------------------------------------------------------------------
+    def _match_tail_dispatch(
+        self, profiles: Sequence[InstructionProfile], idx: int
+    ) -> Optional[MacroSignature]:
+        start = idx
+        total = len(profiles)
+        helper_count = 0
+        cursor = idx
+
+        while cursor < total and profiles[cursor].kind in {InstructionKind.CALL, InstructionKind.META} and not self._is_tail_dispatch(profiles[cursor]):
+            helper_count += 1
+            cursor += 1
+
+        if cursor >= total:
+            return None
+
+        if not self._is_tail_dispatch(profiles[cursor]):
+            if start == cursor and self._is_tail_dispatch(profiles[cursor]):
+                pass
+            else:
+                if self._is_tail_dispatch(profiles[idx]):
+                    cursor = idx
+                else:
+                    return None
+
+        if self._is_tail_dispatch(profiles[cursor]):
+            end = cursor + 1
+            extra = {"helper_count": helper_count, "tail_label": profiles[cursor].label}
+            return MacroSignature(
+                name="tail_dispatch",
+                kind=InstructionKind.MACRO_CALL,
+                category="call",
+                start=start,
+                end=end,
+                extra=extra,
+            )
+
+        return None
+
+    def _match_frame_return(
+        self, profiles: Sequence[InstructionProfile], idx: int
+    ) -> Optional[MacroSignature]:
+        total = len(profiles)
+        cursor = idx
+        teardown = 0
+
+        if self._is_tail_dispatch(profiles[cursor]):
+            return None
+
+        while cursor < total and profiles[cursor].kind is InstructionKind.STACK_TEARDOWN:
+            teardown += 1
+            cursor += 1
+
+        if cursor >= total:
+            return None
+
+        if profiles[cursor].kind not in {InstructionKind.RETURN, InstructionKind.TERMINATOR}:
+            return None
+
+        end = cursor + 1
+        while end < total and profiles[end].kind in {InstructionKind.RETURN, InstructionKind.TERMINATOR}:
+            end += 1
+
+        extra = {"teardown_count": teardown}
+        return MacroSignature(
+            name="frame_return",
+            kind=InstructionKind.MACRO_FRAME_END,
+            category="return",
+            start=idx,
+            end=end,
+            extra=extra,
+        )
+
+    def _match_literal_reduce(
+        self, profiles: Sequence[InstructionProfile], idx: int
+    ) -> Optional[MacroSignature]:
+        total = len(profiles)
+        cursor = idx
+        literals = 0
+
+        while cursor < total and profiles[cursor].kind in LiteralLikeKinds:
+            literals += 1
+            cursor += 1
+
+        if literals == 0 or cursor >= total:
+            return None
+
+        reduce_count = 0
+        table_like = False
+
+        while cursor < total and profiles[cursor].kind in {
+            InstructionKind.REDUCE,
+            InstructionKind.TABLE_LOOKUP,
+        }:
+            reduce_count += 1
+            if profiles[cursor].kind is InstructionKind.TABLE_LOOKUP or (
+                isinstance(profiles[cursor].category, str)
+                and "table" in profiles[cursor].category.lower()
+            ):
+                table_like = True
+            cursor += 1
+
+        if reduce_count == 0:
+            return None
+
+        name = "literal_array_builder"
+        category = "literal_array"
+        kind = InstructionKind.MACRO_LITERAL_ARRAY
+
+        if table_like:
+            name = "literal_table_builder"
+            category = "literal_table"
+            kind = InstructionKind.MACRO_LITERAL_TABLE
+        elif reduce_count > 1:
+            name = "literal_tuple_builder"
+            category = "literal_tuple"
+            kind = InstructionKind.MACRO_LITERAL_TUPLE
+
+        extra = {
+            "literal_count": literals,
+            "reduce_count": reduce_count,
+        }
+        return MacroSignature(
+            name=name,
+            kind=kind,
+            category=category,
+            start=idx,
+            end=cursor,
+            extra=extra,
+        )
+
+    def _match_predicate(
+        self, profiles: Sequence[InstructionProfile], idx: int
+    ) -> Optional[MacroSignature]:
+        profile = profiles[idx]
+
+        category = (profile.category or "").lower()
+        mnemonic = profile.mnemonic.lower()
+        summary = (profile.summary or "").lower()
+
+        if not (
+            "test" in category
+            or "test" in mnemonic
+            or "test" in summary
+        ):
+            return None
+
+        if profile.kind not in {InstructionKind.BRANCH, InstructionKind.TEST}:
+            return None
+
+        return MacroSignature(
+            name="predicate_assign",
+            kind=InstructionKind.MACRO_PREDICATE,
+            category="predicate",
+            start=idx,
+            end=idx + 1,
+            extra={"source_label": profile.label},
+        )
+
+    def _match_indirect_access(
+        self, profiles: Sequence[InstructionProfile], idx: int
+    ) -> Optional[MacroSignature]:
+        profile = profiles[idx]
+        if profile.kind not in {
+            InstructionKind.INDIRECT,
+            InstructionKind.INDIRECT_LOAD,
+            InstructionKind.INDIRECT_STORE,
+            InstructionKind.TABLE_LOOKUP,
+        }:
+            return None
+
+        operand = profile.operand
+        if operand < 0x2000:
+            name = "frame_slot_access"
+            category = "frame_access"
+            kind = InstructionKind.MACRO_FRAME_SLOT
+            zone = "frame"
+        else:
+            name = "global_slot_access"
+            category = "global_access"
+            kind = InstructionKind.MACRO_GLOBAL_SLOT
+            zone = "global"
+
+        extra = {
+            "zone": zone,
+            "operand": operand,
+        }
+        return MacroSignature(
+            name=name,
+            kind=kind,
+            category=category,
+            start=idx,
+            end=idx + 1,
+            extra=extra,
+        )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _apply_match(profiles: Sequence[InstructionProfile], match: MacroSignature) -> None:
+        leader = profiles[match.start]
+        leader.tag_macro(match.name, match.kind, category=match.category, span=match.span, extra=match.extra)
+        for position in range(match.start + 1, match.end):
+            profiles[position].mark_macro_member(match.name)
+
+    @staticmethod
+    def _is_tail_dispatch(profile: InstructionProfile) -> bool:
+        if profile.kind is InstructionKind.TAILCALL:
+            return True
+        mnemonic = profile.mnemonic.lower()
+        if "tail" in mnemonic:
+            return True
+        if profile.label.startswith("29:"):
+            return True
+        category = (profile.category or "").lower()
+        if "tail" in category:
+            return True
+        return False

--- a/mbcdisasm/analyzer/pipeline.py
+++ b/mbcdisasm/analyzer/pipeline.py
@@ -15,6 +15,7 @@ from .instruction_profile import (
 from .diagnostics import DiagnosticBuilder
 from .dfa import DeterministicAutomaton
 from .heuristics import HeuristicEngine, HeuristicReport
+from .normalizer import MacroNormalizer
 from .patterns import PatternMatch, PatternRegistry, default_patterns
 from .signatures import SignatureDetector
 from .stats import StatisticsBuilder
@@ -49,6 +50,7 @@ class PipelineAnalyzer:
         self.statistics_builder = StatisticsBuilder()
         self.automaton = DeterministicAutomaton(self.registry)
         self.signatures = SignatureDetector()
+        self.normalizer = MacroNormalizer()
 
     # ------------------------------------------------------------------
     # public API
@@ -69,7 +71,9 @@ class PipelineAnalyzer:
     # helpers
     # ------------------------------------------------------------------
     def _profile_instructions(self, instructions: Sequence[InstructionWord]) -> Tuple[InstructionProfile, ...]:
-        return tuple(InstructionProfile.from_word(word, self.knowledge) for word in instructions)
+        profiles = [InstructionProfile.from_word(word, self.knowledge) for word in instructions]
+        self.normalizer.apply(profiles)
+        return tuple(profiles)
 
     def _compute_events(self, profiles: Sequence[InstructionProfile]) -> Tuple[StackEvent, ...]:
         tracker = StackTracker()

--- a/mbcdisasm/analyzer/report.py
+++ b/mbcdisasm/analyzer/report.py
@@ -42,7 +42,8 @@ class PipelineBlock:
     def histogram(self) -> dict[InstructionKind, int]:
         counts: dict[InstructionKind, int] = {}
         for profile in self.profiles:
-            counts[profile.kind] = counts.get(profile.kind, 0) + 1
+            kind = profile.normalized_kind
+            counts[kind] = counts.get(kind, 0) + 1
         return counts
 
     def add_note(self, message: str) -> None:

--- a/mbcdisasm/analyzer/stats.py
+++ b/mbcdisasm/analyzer/stats.py
@@ -105,7 +105,7 @@ class StatisticsBuilder:
             total_delta += block.stack.change
             categories.setdefault(block.category, CategoryStats()).record(block)
             for profile in block.profiles:
-                kind_stats.record(profile.kind)
+                kind_stats.record(profile.normalized_kind)
 
         return PipelineStatistics(
             block_count=len(blocks),

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+from mbcdisasm.analyzer.normalizer import MacroNormalizer
+from mbcdisasm.analyzer.instruction_profile import InstructionKind, InstructionProfile
+from mbcdisasm.instruction import InstructionWord
+from mbcdisasm.knowledge import KnowledgeBase
+
+
+def make_word(opcode: int, mode: int = 0, operand: int = 0, offset: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def build_profiles(words):
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    profiles = [InstructionProfile.from_word(word, knowledge) for word in words]
+    normalizer = MacroNormalizer()
+    normalizer.apply(profiles)
+    return profiles
+
+
+def test_tail_dispatch_and_frame_return_macros():
+    words = [
+        make_word(0x16, 0x01, 0, 0),  # call helper
+        make_word(0x29, 0x10, 0, 4),  # tail dispatch
+        make_word(0x01, 0x08, 0, 8),  # frame teardown
+        make_word(0x30, 0x00, 0, 12),  # return
+    ]
+    profiles = build_profiles(words)
+
+    leader = profiles[0]
+    assert leader.traits.get("macro") == "tail_dispatch"
+    assert leader.traits.get("macro_kind") is InstructionKind.MACRO_CALL
+    assert profiles[1].traits.get("macro_member") == "tail_dispatch"
+
+    frame_return = profiles[2]
+    assert frame_return.traits.get("macro") == "frame_return"
+    assert frame_return.traits.get("macro_kind") is InstructionKind.MACRO_FRAME_END
+    assert profiles[3].traits.get("macro_member") == "frame_return"
+
+
+def test_literal_reduce_chain_collapses_into_array_builder():
+    words = [
+        make_word(0x00, 0x00, 0x0010, 0),
+        make_word(0x00, 0x00, 0x0011, 4),
+        make_word(0x00, 0x00, 0x0012, 8),
+        make_word(0x04, 0x00, 0x0000, 12),
+    ]
+    profiles = build_profiles(words)
+
+    leader = profiles[0]
+    assert leader.traits.get("macro") == "literal_array_builder"
+    assert leader.traits.get("macro_kind") is InstructionKind.MACRO_LITERAL_ARRAY
+    assert leader.traits.get("literal_count") == 3
+    assert profiles[1].traits.get("macro_member") == "literal_array_builder"
+
+
+def test_predicate_branch_promoted_to_macro():
+    words = [make_word(0x26, 0x00, 0x0002, 0)]
+    profiles = build_profiles(words)
+
+    leader = profiles[0]
+    assert leader.traits.get("macro") == "predicate_assign"
+    assert leader.traits.get("macro_kind") is InstructionKind.MACRO_PREDICATE
+
+
+def test_indirect_access_zones_are_tagged():
+    words = [
+        make_word(0x69, 0x01, 0x0010, 0),  # frame slot
+        make_word(0x69, 0x20, 0x4000, 4),  # global slot
+    ]
+    profiles = build_profiles(words)
+
+    frame = profiles[0]
+    assert frame.traits.get("macro") == "frame_slot_access"
+    assert frame.traits.get("zone") == "frame"
+    assert frame.traits.get("macro_kind") is InstructionKind.MACRO_FRAME_SLOT
+
+    glob = profiles[1]
+    assert glob.traits.get("macro") == "global_slot_access"
+    assert glob.traits.get("zone") == "global"
+    assert glob.traits.get("macro_kind") is InstructionKind.MACRO_GLOBAL_SLOT


### PR DESCRIPTION
## Summary
- add a MacroNormalizer that collapses tail dispatch, frame returns, literal reduce chains, predicate branches, and indirect accesses into canonical macro operations
- extend instruction profiling to tag macros and expose normalised kinds so reports, statistics, and the pipeline share the higher-level view
- add unit coverage for the normaliser behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa2244430832fb75b0f9bbd2c449b