### PR TITLE
Add macro normalizer for pipeline blocks

### DIFF
--- a/mbcdisasm/analyzer/normalizer.py
+++ b/mbcdisasm/analyzer/normalizer.py
@@ -1,0 +1,259 @@
+"""Normalize instruction blocks into macro-level operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+from .instruction_profile import InstructionKind, InstructionProfile
+from .stack import StackEvent, StackSummary
+
+
+@dataclass(frozen=True)
+class NormalizedOperation:
+    """High level operation recovered from a block of instructions."""
+
+    name: str
+    category: str
+    start_offset: int
+    end_offset: int
+    length: int
+    notes: Tuple[str, ...] = tuple()
+
+    def describe(self) -> str:
+        span = f"[{self.start_offset:08X}-{self.end_offset:08X}]"
+        base = f"{self.name} {span} category={self.category} len={self.length}"
+        if self.notes:
+            return base + " " + ", ".join(self.notes)
+        return base
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "category": self.category,
+            "start_offset": self.start_offset,
+            "end_offset": self.end_offset,
+            "length": self.length,
+            "notes": list(self.notes),
+        }
+
+
+class MacroNormalizer:
+    """Collapse low level instruction streams into macro operations."""
+
+    def normalize(
+        self,
+        profiles: Sequence[InstructionProfile],
+        stack: StackSummary,
+    ) -> Tuple[NormalizedOperation, ...]:
+        if not profiles:
+            return tuple()
+        events = stack.events or tuple()
+        operations: List[NormalizedOperation] = []
+        operations.extend(self._tail_and_return_macros(profiles))
+        operations.extend(self._literal_reduction_macros(profiles))
+        operations.extend(self._predicate_macros(profiles))
+        operations.extend(self._indirect_macros(profiles, events))
+        operations.sort(key=lambda op: op.start_offset)
+        return tuple(operations)
+
+    # ------------------------------------------------------------------
+    # macro detectors
+    # ------------------------------------------------------------------
+    def _tail_and_return_macros(
+        self, profiles: Sequence[InstructionProfile]
+    ) -> List[NormalizedOperation]:
+        operations: List[NormalizedOperation] = []
+        call_indices = [
+            idx
+            for idx, profile in enumerate(profiles)
+            if profile.kind in {InstructionKind.TAILCALL, InstructionKind.CALL}
+        ]
+        if call_indices:
+            first = call_indices[0]
+            last = call_indices[-1]
+            start = profiles[first].word.offset
+            end = profiles[last].word.offset
+            names = {profile.mnemonic for profile in profiles[first : last + 1]}
+            notes = tuple(sorted(names))
+            has_tail = any(
+                profile.kind is InstructionKind.TAILCALL
+                for profile in profiles[first : last + 1]
+            )
+            name = "tail_dispatch" if has_tail else "call_dispatch"
+            operations.append(
+                NormalizedOperation(
+                    name=name,
+                    category="call",
+                    start_offset=start,
+                    end_offset=end,
+                    length=last - first + 1,
+                    notes=notes,
+                )
+            )
+
+        return_indices = [
+            idx
+            for idx, profile in enumerate(profiles)
+            if profile.kind in {InstructionKind.RETURN, InstructionKind.TERMINATOR}
+        ]
+        if return_indices:
+            first = return_indices[0]
+            last = return_indices[-1]
+            start = profiles[first].word.offset
+            end = profiles[last].word.offset
+            mnemonics = {profile.mnemonic for profile in profiles[first : last + 1]}
+            notes = tuple(sorted(mnemonics))
+            operations.append(
+                NormalizedOperation(
+                    name="frame_end",
+                    category="return",
+                    start_offset=start,
+                    end_offset=end,
+                    length=last - first + 1,
+                    notes=notes,
+                )
+            )
+        return operations
+
+    def _literal_reduction_macros(
+        self, profiles: Sequence[InstructionProfile]
+    ) -> List[NormalizedOperation]:
+        operations: List[NormalizedOperation] = []
+        literal_like = {
+            InstructionKind.LITERAL,
+            InstructionKind.ASCII_CHUNK,
+            InstructionKind.PUSH,
+            InstructionKind.TABLE_LOOKUP,
+        }
+        for idx, profile in enumerate(profiles):
+            if profile.kind is not InstructionKind.REDUCE:
+                continue
+            left = idx - 1
+            while left >= 0:
+                previous = profiles[left]
+                if previous.kind in literal_like or previous.kind is InstructionKind.META:
+                    left -= 1
+                    continue
+                if previous.is_literal_marker():
+                    left -= 1
+                    continue
+                break
+            left += 1
+            run = profiles[left:idx]
+            if len(run) < 2:
+                continue
+            has_push = any(item.kind is InstructionKind.PUSH for item in run)
+            has_table = any(item.kind is InstructionKind.TABLE_LOOKUP for item in run)
+            has_ascii = any(item.kind is InstructionKind.ASCII_CHUNK for item in run)
+            if has_push or has_table:
+                name = "table_build"
+            elif has_ascii:
+                name = "tuple_build"
+            else:
+                name = "array_build"
+            notes = [f"reduce={profile.label}"]
+            notes.append(f"literals={len(run)}")
+            operations.append(
+                NormalizedOperation(
+                    name=name,
+                    category="literal",
+                    start_offset=profiles[left].word.offset,
+                    end_offset=profile.word.offset,
+                    length=idx - left + 1,
+                    notes=tuple(notes),
+                )
+            )
+        return operations
+
+    def _predicate_macros(
+        self, profiles: Sequence[InstructionProfile]
+    ) -> List[NormalizedOperation]:
+        operations: List[NormalizedOperation] = []
+        literal_like = {
+            InstructionKind.LITERAL,
+            InstructionKind.PUSH,
+            InstructionKind.TABLE_LOOKUP,
+        }
+        for idx, profile in enumerate(profiles):
+            if profile.kind is not InstructionKind.TEST:
+                continue
+            start_idx = idx
+            notes: List[str] = [f"test={profile.label}"]
+            if idx > 0 and (
+                profiles[idx - 1].kind in literal_like
+                or profiles[idx - 1].is_literal_marker()
+            ):
+                start_idx = idx - 1
+                notes.append(f"source={profiles[idx - 1].label}")
+            operations.append(
+                NormalizedOperation(
+                    name="predicate_assign",
+                    category="predicate",
+                    start_offset=profiles[start_idx].word.offset,
+                    end_offset=profile.word.offset,
+                    length=idx - start_idx + 1,
+                    notes=tuple(notes),
+                )
+            )
+        return operations
+
+    def _indirect_macros(
+        self,
+        profiles: Sequence[InstructionProfile],
+        events: Sequence[StackEvent],
+    ) -> List[NormalizedOperation]:
+        operations: List[NormalizedOperation] = []
+        for idx, profile in enumerate(profiles):
+            if not profile.label.startswith("69:"):
+                continue
+            operand = profile.operand
+            zone = classify_address_zone(operand)
+            action = "load"
+            if idx < len(events):
+                event = events[idx]
+                if event.kind is InstructionKind.INDIRECT_STORE:
+                    action = "store"
+                elif event.kind is InstructionKind.INDIRECT_LOAD:
+                    action = "load"
+            notes = [f"zone={zone}", f"addr=0x{operand:04X}"]
+            if profile.mode:
+                notes.append(f"mode=0x{profile.mode:02X}")
+            operations.append(
+                NormalizedOperation(
+                    name=f"indirect_{action}",
+                    category="memory",
+                    start_offset=profile.word.offset,
+                    end_offset=profile.word.offset,
+                    length=1,
+                    notes=tuple(notes),
+                )
+            )
+        return operations
+
+
+def classify_address_zone(operand: int) -> str:
+    """Return a coarse address zone for ``operand`` used by indirect ops."""
+
+    if operand < 0:
+        return "unknown"
+    zone_selector = (operand >> 12) & 0xF
+    zone_map = {
+        0x0: "frame.locals",
+        0x1: "frame.locals",
+        0x2: "frame.environment",
+        0x3: "frame.environment",
+        0x4: "global.shared",
+        0x5: "global.shared",
+        0x6: "global.shared",
+        0x7: "global.shared",
+        0x8: "global.constants",
+        0x9: "global.constants",
+        0xA: "global.constants",
+        0xB: "global.constants",
+        0xC: "global.state",
+        0xD: "global.state",
+        0xE: "global.state",
+        0xF: "global.state",
+    }
+    return zone_map.get(zone_selector, "global.state")

--- a/mbcdisasm/analyzer/report.py
+++ b/mbcdisasm/analyzer/report.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 from .instruction_profile import InstructionKind, InstructionProfile, dominant_kind
+from .normalizer import NormalizedOperation
 from .patterns import PatternMatch
 from .stack import StackSummary
 from .stats import PipelineStatistics
@@ -21,6 +22,7 @@ class PipelineBlock:
     category: str
     pattern: Optional[PatternMatch] = None
     confidence: float = 0.0
+    normalized: Tuple[NormalizedOperation, ...] = field(default_factory=tuple)
     notes: List[str] = field(default_factory=list)
 
     @property
@@ -59,6 +61,7 @@ class PipelineBlock:
             "stack_max": self.stack.maximum,
             "confidence": self.confidence,
             "pattern": self.pattern.pattern.name if self.pattern else None,
+            "normalized": [operation.as_dict() for operation in self.normalized],
             "notes": list(self.notes),
         }
 
@@ -101,6 +104,8 @@ def build_block(
     category: str,
     confidence: float,
     notes: Optional[Iterable[str]] = None,
+    *,
+    normalized: Optional[Sequence[NormalizedOperation]] = None,
 ) -> PipelineBlock:
     dominant = dominant_kind(profiles)
     block = PipelineBlock(
@@ -110,6 +115,7 @@ def build_block(
         category=category,
         pattern=pattern,
         confidence=confidence,
+        normalized=tuple(normalized or ()),
     )
     for note in notes or []:
         block.add_note(note)

--- a/mbcdisasm/disassembler.py
+++ b/mbcdisasm/disassembler.py
@@ -184,9 +184,19 @@ class Disassembler:
             f"len={len(block.profiles)} pattern={pattern} conf={block.confidence:.2f}"
         )
         lines = [header]
+        macro_lines = self._format_block_macros(block.normalized)
+        lines.extend(macro_lines)
         note_lines = self._format_block_notes(block.notes)
         lines.extend(note_lines)
         return lines
+
+    @staticmethod
+    def _format_block_macros(macros):
+        formatted: List[str] = []
+        for operation in macros:
+            details = operation.describe()
+            formatted.append(f";   macro: {details}")
+        return formatted
 
     @staticmethod
     def _format_block_notes(notes: Iterable[str]) -> List[str]:

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,166 @@
+from mbcdisasm.analyzer.instruction_profile import InstructionProfile
+from mbcdisasm.analyzer.normalizer import MacroNormalizer
+from mbcdisasm.analyzer.report import build_block
+from mbcdisasm.analyzer.stack import StackTracker
+from mbcdisasm.analyzer.stats import StatisticsBuilder
+from mbcdisasm.instruction import InstructionWord
+from mbcdisasm.knowledge import KnowledgeBase, OpcodeInfo
+
+
+def make_word(opcode: int, mode: int = 0, operand: int = 0, offset: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def build_knowledge() -> KnowledgeBase:
+    annotations = {
+        "00:00": OpcodeInfo(
+            mnemonic="literal",
+            summary="literal",
+            category="literal",
+            stack_delta=1,
+        ),
+        "02:00": OpcodeInfo(
+            mnemonic="push",
+            summary="push",
+            category="push",
+            stack_delta=1,
+        ),
+        "04:00": OpcodeInfo(
+            mnemonic="reduce",
+            summary="reduce",
+            category="reduce",
+            stack_delta=-1,
+        ),
+        "26:00": OpcodeInfo(
+            mnemonic="test_branch",
+            summary="test",
+            category="test",
+            stack_delta=-1,
+        ),
+        "29:10": OpcodeInfo(
+            mnemonic="tail_dispatch",
+            summary="tailcall",
+            control_flow="call",
+            category="tailcall",
+            stack_delta=0,
+        ),
+        "30:00": OpcodeInfo(
+            mnemonic="return",
+            summary="return",
+            control_flow="return",
+            category="return",
+            stack_delta=-1,
+        ),
+        "69:10": OpcodeInfo(
+            mnemonic="indirect_access",
+            summary="indirect",
+            category="indirect",
+            stack_delta=0,
+        ),
+        "69:00": OpcodeInfo(
+            mnemonic="indirect_access",
+            summary="indirect",
+            category="indirect",
+            stack_delta=0,
+        ),
+    }
+    return KnowledgeBase(annotations)
+
+
+def load_profiles(words):
+    knowledge = build_knowledge()
+    return [InstructionProfile.from_word(word, knowledge) for word in words]
+
+
+def make_summary(profiles):
+    tracker = StackTracker()
+    return tracker.process_block(profiles)
+
+
+def test_tailcall_and_return_collapse_into_macros():
+    words = [
+        make_word(0x29, 0x10, 0, 0),
+        make_word(0x30, 0x00, 0, 4),
+    ]
+    profiles = load_profiles(words)
+    summary = make_summary(profiles)
+
+    normalizer = MacroNormalizer()
+    operations = normalizer.normalize(profiles, summary)
+    names = {operation.name for operation in operations}
+
+    assert "tail_dispatch" in names
+    assert "frame_end" in names
+
+
+def test_literal_reduce_forms_table_macro():
+    words = [
+        make_word(0x00, 0x00, 0x0001, 0),
+        make_word(0x02, 0x00, 0x0000, 4),
+        make_word(0x00, 0x00, 0x0002, 8),
+        make_word(0x04, 0x00, 0x0000, 12),
+    ]
+    profiles = load_profiles(words)
+    summary = make_summary(profiles)
+
+    operations = MacroNormalizer().normalize(profiles, summary)
+    tables = [operation for operation in operations if operation.name == "table_build"]
+    assert tables
+    table = tables[0]
+    assert any(note == "literals=3" for note in table.notes)
+
+
+def test_predicate_assignment_macro_detected():
+    words = [
+        make_word(0x00, 0x00, 0x0010, 0),
+        make_word(0x26, 0x00, 0x0000, 4),
+    ]
+    profiles = load_profiles(words)
+    summary = make_summary(profiles)
+
+    operations = MacroNormalizer().normalize(profiles, summary)
+    predicate = [operation for operation in operations if operation.name == "predicate_assign"]
+    assert predicate
+    notes = predicate[0].notes
+    assert any(entry.startswith("source=") for entry in notes)
+
+
+def test_indirect_access_grouped_by_zone():
+    words = [
+        make_word(0x69, 0x10, 0x0005, 0),
+        make_word(0x69, 0x10, 0xED00, 4),
+    ]
+    profiles = load_profiles(words)
+    summary = make_summary(profiles)
+
+    operations = MacroNormalizer().normalize(profiles, summary)
+    zones = [entry for op in operations for entry in op.notes if entry.startswith("zone=")]
+    assert "zone=frame.locals" in zones
+    assert "zone=global.state" in zones
+
+
+def test_statistics_collects_macro_categories():
+    words = [
+        make_word(0x00, 0x00, 0x0001, 0),
+        make_word(0x00, 0x00, 0x0002, 4),
+        make_word(0x04, 0x00, 0x0000, 8),
+        make_word(0x29, 0x10, 0x0000, 12),
+        make_word(0x30, 0x00, 0x0000, 16),
+    ]
+    profiles = load_profiles(words)
+    summary = make_summary(profiles)
+    normalized = MacroNormalizer().normalize(profiles, summary)
+
+    block = build_block(
+        profiles,
+        summary,
+        pattern=None,
+        category="literal",
+        confidence=0.5,
+        normalized=normalized,
+    )
+    stats = StatisticsBuilder().collect([block])
+    assert stats.macro_categories.get("literal", 0) >= 1
+    assert stats.macro_categories.get("call", 0) >= 1
+    assert stats.macro_categories.get("return", 0) >= 1


### PR DESCRIPTION
## Summary
- add a MacroNormalizer to collapse literal, call/return, predicate and indirect access sequences into macro operations recorded on pipeline blocks
- include the normalized operations in pipeline statistics and in the generated listing output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa2244430832fb75b0f9bbd2c449b