### PR TITLE
Add macro normalizer with canonical signatures

### DIFF
--- a/mbcdisasm/analyzer/__init__.py
+++ b/mbcdisasm/analyzer/__init__.py
@@ -41,7 +41,16 @@ information to build higher level control flow graphs or to detect suspicious
 patterns that need manual review.
 """
 
+from .normalizer import IntermediateSummary, MacroNormalizer, NormalizedBlock, NormalizedOp
 from .pipeline import PipelineAnalyzer
 from .report import PipelineBlock, PipelineReport
 
-__all__ = ["PipelineAnalyzer", "PipelineBlock", "PipelineReport"]
+__all__ = [
+    "PipelineAnalyzer",
+    "PipelineBlock",
+    "PipelineReport",
+    "MacroNormalizer",
+    "NormalizedBlock",
+    "NormalizedOp",
+    "IntermediateSummary",
+]

--- a/mbcdisasm/analyzer/normalizer.py
+++ b/mbcdisasm/analyzer/normalizer.py
@@ -1,0 +1,279 @@
+"""Normalize pipeline blocks into macro-level operations.
+
+The pipeline analyser already recognises clusters of instructions that behave
+like cohesive execution units – literal trains, call preparation helpers,
+tailcall dispatchers and so on.  Downstream tooling, however, still has to sift
+through the low-level instruction mix when building intermediate code.  The
+``MacroNormalizer`` implemented in this module bridges that gap by collapsing
+well-known patterns into *macro operations*.  These macros expose the intent of
+the block ("tail dispatch", "build table", "predicate assignment") while hiding
+the instruction bookkeeping that previously polluted corpus statistics.
+
+The normaliser is intentionally conservative: only patterns that are stable
+across all inspected `.mbc` corpora are promoted to macros.  Everything else is
+folded into a generic ``raw_block`` descriptor so that callers can still build a
+complete representation without second-guessing the heuristics.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence, Tuple
+
+from .instruction_profile import InstructionKind, InstructionProfile
+from .report import PipelineBlock, PipelineReport
+
+
+LiteralKinds = {
+    InstructionKind.LITERAL,
+    InstructionKind.ASCII_CHUNK,
+    InstructionKind.PUSH,
+    InstructionKind.TABLE_LOOKUP,
+}
+
+
+@dataclass(frozen=True)
+class NormalizedOp:
+    """Single macro-level operation produced by the normaliser."""
+
+    macro: str
+    operands: Tuple[str, ...] = tuple()
+    sources: Tuple[str, ...] = tuple()
+    notes: Tuple[str, ...] = tuple()
+
+
+@dataclass(frozen=True)
+class NormalizedBlock:
+    """Container tying a :class:`PipelineBlock` to its macro operations."""
+
+    block: PipelineBlock
+    operations: Tuple[NormalizedOp, ...]
+
+
+@dataclass(frozen=True)
+class IntermediateSummary:
+    """Aggregated statistics over normalised blocks."""
+
+    operation_counts: Mapping[str, int]
+    block_count: int
+
+    def describe(self) -> str:
+        parts = [f"blocks={self.block_count}"]
+        for name, count in sorted(self.operation_counts.items()):
+            parts.append(f"{name}:{count}")
+        return " ".join(parts)
+
+
+class MacroNormalizer:
+    """Collapse low-level instruction streams into macro operations."""
+
+    def normalize_block(self, block: PipelineBlock) -> NormalizedBlock:
+        """Return macro operations describing ``block``."""
+
+        operations: list[NormalizedOp] = []
+
+        tail_macro = self._detect_tail_dispatch(block)
+        if tail_macro is not None:
+            return NormalizedBlock(block=block, operations=(tail_macro,))
+
+        return_macro = self._detect_return(block)
+        if return_macro is not None:
+            return NormalizedBlock(block=block, operations=(return_macro,))
+
+        literal_macro = self._detect_literal_build(block)
+        if literal_macro is not None:
+            operations.append(literal_macro)
+
+        predicate_macro = self._detect_predicate(block)
+        if predicate_macro is not None:
+            operations.append(predicate_macro)
+
+        operations.extend(self._detect_indirect_access(block))
+
+        if not operations:
+            operations.append(self._fallback_macro(block))
+
+        return NormalizedBlock(block=block, operations=tuple(operations))
+
+    def normalize_report(
+        self, report: PipelineReport | Sequence[PipelineBlock]
+    ) -> Tuple[NormalizedBlock, ...]:
+        """Normalise all blocks contained in ``report``."""
+
+        if isinstance(report, PipelineReport):
+            blocks = report.blocks
+        else:
+            blocks = tuple(report)
+        return tuple(self.normalize_block(block) for block in blocks)
+
+    def summarise(self, blocks: Iterable[NormalizedBlock]) -> IntermediateSummary:
+        """Return an :class:`IntermediateSummary` for ``blocks``."""
+
+        counter: Counter[str] = Counter()
+        count = 0
+        for normalized in blocks:
+            count += 1
+            for operation in normalized.operations:
+                counter[operation.macro] += 1
+        return IntermediateSummary(operation_counts=dict(counter), block_count=count)
+
+    def evaluate(self, report: PipelineReport) -> IntermediateSummary:
+        """Convenience wrapper combining :meth:`normalize_report` and :meth:`summarise`."""
+
+        normalized = self.normalize_report(report)
+        return self.summarise(normalized)
+
+    # ------------------------------------------------------------------
+    # detection helpers
+    # ------------------------------------------------------------------
+    def _detect_tail_dispatch(self, block: PipelineBlock) -> NormalizedOp | None:
+        labels = [profile.label for profile in block.profiles if self._is_tail(profile)]
+        if not labels:
+            return None
+
+        operands = []
+        if block.stack.change:
+            operands.append(f"stackΔ={block.stack.change:+d}")
+        notes = (block.category,) if block.category else tuple()
+        return NormalizedOp(
+            macro="tail_dispatch",
+            operands=tuple(operands),
+            sources=tuple(labels),
+            notes=notes,
+        )
+
+    def _detect_return(self, block: PipelineBlock) -> NormalizedOp | None:
+        labels = [
+            profile.label
+            for profile in block.profiles
+            if profile.kind in {InstructionKind.RETURN, InstructionKind.TERMINATOR}
+        ]
+        if not labels:
+            return None
+
+        operands = []
+        if block.stack.change:
+            operands.append(f"stackΔ={block.stack.change:+d}")
+        notes = (block.category,) if block.category else tuple()
+        return NormalizedOp(
+            macro="frame_return",
+            operands=tuple(operands),
+            sources=tuple(labels),
+            notes=notes,
+        )
+
+    def _detect_literal_build(self, block: PipelineBlock) -> NormalizedOp | None:
+        literal_profiles: list[InstructionProfile] = []
+        reduce_labels: list[str] = []
+
+        index = 0
+        for profile in block.profiles:
+            if profile.kind in LiteralKinds:
+                literal_profiles.append(profile)
+                index += 1
+                continue
+            break
+
+        if len(literal_profiles) < 2:
+            return None
+
+        reduce_count = 0
+        for profile in block.profiles[index:]:
+            if profile.kind is InstructionKind.REDUCE:
+                reduce_count += 1
+                reduce_labels.append(profile.label)
+            else:
+                break
+
+        if reduce_count == 0:
+            return None
+
+        has_push = any(profile.kind is InstructionKind.PUSH for profile in literal_profiles)
+        literal_labels = [profile.label for profile in literal_profiles]
+
+        if has_push:
+            macro = "table_build"
+        elif len(literal_profiles) == 2 and reduce_count == 1:
+            macro = "tuple_build"
+        else:
+            macro = "array_build"
+
+        operands = (
+            f"width={len(literal_profiles)}",
+            f"reduces={reduce_count}",
+        )
+        return NormalizedOp(
+            macro=macro,
+            operands=operands,
+            sources=tuple(literal_labels + reduce_labels),
+        )
+
+    def _detect_predicate(self, block: PipelineBlock) -> NormalizedOp | None:
+        test_indices = [idx for idx, profile in enumerate(block.profiles) if profile.kind is InstructionKind.TEST]
+        if not test_indices:
+            return None
+
+        sources = [block.profiles[idx].label for idx in test_indices]
+        operands: list[str] = [f"tests={len(test_indices)}"]
+
+        first_test = test_indices[0]
+        if first_test > 0:
+            target = block.profiles[first_test - 1]
+            if target.kind is InstructionKind.PUSH:
+                operands.append(f"target={target.label}")
+
+        return NormalizedOp(
+            macro="predicate_assign",
+            operands=tuple(operands),
+            sources=tuple(sources),
+        )
+
+    def _detect_indirect_access(self, block: PipelineBlock) -> list[NormalizedOp]:
+        operations: list[NormalizedOp] = []
+        for profile in block.profiles:
+            if not self._is_indirect(profile):
+                continue
+            zone = "frame" if profile.mode < 0x20 else "global"
+            macro = f"{zone}_access"
+            operands = (f"slot=0x{profile.mode:02X}",)
+            operations.append(
+                NormalizedOp(
+                    macro=macro,
+                    operands=operands,
+                    sources=(profile.label,),
+                )
+            )
+        return operations
+
+    def _fallback_macro(self, block: PipelineBlock) -> NormalizedOp:
+        operands = (
+            f"category={block.category}",
+            f"instr={len(block.profiles)}",
+        )
+        labels = tuple(profile.label for profile in block.profiles)
+        return NormalizedOp(macro="raw_block", operands=operands, sources=labels)
+
+    @staticmethod
+    def _is_tail(profile: InstructionProfile) -> bool:
+        if profile.kind is InstructionKind.TAILCALL:
+            return True
+        return profile.label.startswith("29:")
+
+    @staticmethod
+    def _is_indirect(profile: InstructionProfile) -> bool:
+        if profile.kind in {
+            InstructionKind.INDIRECT,
+            InstructionKind.INDIRECT_LOAD,
+            InstructionKind.INDIRECT_STORE,
+        }:
+            return True
+        return profile.label.startswith("69:")
+
+
+__all__ = [
+    "MacroNormalizer",
+    "NormalizedBlock",
+    "NormalizedOp",
+    "IntermediateSummary",
+]

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,187 @@
+from mbcdisasm.analyzer import (
+    IntermediateSummary,
+    MacroNormalizer,
+    PipelineBlock,
+    PipelineReport,
+)
+from mbcdisasm.analyzer.instruction_profile import InstructionProfile
+from mbcdisasm.analyzer.report import build_block as build_pipeline_block
+from mbcdisasm.analyzer.stack import StackTracker
+from mbcdisasm.instruction import InstructionWord
+from mbcdisasm.knowledge import KnowledgeBase, OpcodeInfo
+
+
+def make_word(offset: int, opcode: int, mode: int = 0, operand: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def build_knowledge() -> KnowledgeBase:
+    annotations = {
+        "10:00": OpcodeInfo(
+            mnemonic="literal",
+            summary="literal",
+            category="literal",
+            stack_delta=1,
+        ),
+        "11:00": OpcodeInfo(
+            mnemonic="push_slot",
+            summary="push",
+            category="push",
+            stack_delta=1,
+        ),
+        "12:00": OpcodeInfo(
+            mnemonic="testset",
+            summary="test",
+            category="test",
+            stack_delta=-1,
+        ),
+        "20:00": OpcodeInfo(
+            mnemonic="reduce",
+            summary="reduce",
+            category="reduce",
+            stack_delta=-1,
+        ),
+        "21:00": OpcodeInfo(
+            mnemonic="indirect",
+            summary="indirect",
+            category="indirect",
+            stack_delta=0,
+        ),
+        "21:10": OpcodeInfo(
+            mnemonic="indirect",
+            summary="indirect",
+            category="indirect",
+            stack_delta=0,
+        ),
+        "21:20": OpcodeInfo(
+            mnemonic="indirect",
+            summary="indirect",
+            category="indirect",
+            stack_delta=0,
+        ),
+        "29:00": OpcodeInfo(
+            mnemonic="tailcall_dispatch",
+            summary="tailcall",
+            control_flow="call",
+            category="tailcall",
+            stack_delta=0,
+        ),
+        "30:00": OpcodeInfo(
+            mnemonic="return",
+            summary="return",
+            control_flow="return",
+            category="return",
+            stack_delta=-1,
+        ),
+    }
+    return KnowledgeBase(annotations)
+
+
+def make_block(words, knowledge: KnowledgeBase, category: str, confidence: float = 0.6) -> PipelineBlock:
+    profiles = tuple(InstructionProfile.from_word(word, knowledge) for word in words)
+    tracker = StackTracker()
+    stack = tracker.process_block(profiles)
+    return build_pipeline_block(profiles, stack, pattern=None, category=category, confidence=confidence)
+
+
+def test_tail_dispatch_collapses_to_macro():
+    knowledge = build_knowledge()
+    block = make_block([make_word(0, 0x29)], knowledge, category="call")
+    normalizer = MacroNormalizer()
+
+    normalized = normalizer.normalize_block(block)
+
+    assert len(normalized.operations) == 1
+    op = normalized.operations[0]
+    assert op.macro == "tail_dispatch"
+    assert op.sources == ("29:00",)
+
+
+def test_return_collapses_to_macro():
+    knowledge = build_knowledge()
+    block = make_block([make_word(0, 0x30)], knowledge, category="return")
+    normalizer = MacroNormalizer()
+
+    normalized = normalizer.normalize_block(block)
+
+    assert len(normalized.operations) == 1
+    op = normalized.operations[0]
+    assert op.macro == "frame_return"
+    assert op.sources == ("30:00",)
+
+
+def test_literal_reduce_forms_tuple_macro():
+    knowledge = build_knowledge()
+    words = [make_word(0, 0x10), make_word(4, 0x10), make_word(8, 0x20)]
+    block = make_block(words, knowledge, category="compute")
+    normalizer = MacroNormalizer()
+
+    normalized = normalizer.normalize_block(block)
+
+    assert normalized.operations[0].macro == "tuple_build"
+    assert normalized.operations[0].operands[0] == "width=2"
+    assert normalized.operations[0].sources == ("10:00", "10:00", "20:00")
+
+
+def test_literal_reduce_with_push_forms_table_macro():
+    knowledge = build_knowledge()
+    words = [make_word(0, 0x11), make_word(4, 0x10), make_word(8, 0x20)]
+    block = make_block(words, knowledge, category="literal")
+    normalizer = MacroNormalizer()
+
+    normalized = normalizer.normalize_block(block)
+
+    assert normalized.operations[0].macro == "table_build"
+    assert "width=2" in normalized.operations[0].operands
+
+
+def test_predicate_assignment_macro():
+    knowledge = build_knowledge()
+    words = [make_word(0, 0x11), make_word(4, 0x12)]
+    block = make_block(words, knowledge, category="test")
+    normalizer = MacroNormalizer()
+
+    normalized = normalizer.normalize_block(block)
+
+    assert any(op.macro == "predicate_assign" for op in normalized.operations)
+    predicate = next(op for op in normalized.operations if op.macro == "predicate_assign")
+    assert "tests=1" in predicate.operands
+    assert "target=11:00" in predicate.operands
+
+
+def test_indirect_access_maps_to_zones():
+    knowledge = build_knowledge()
+    words = [make_word(0, 0x21, mode) for mode in (0x10, 0x20)]
+    block = make_block(words, knowledge, category="indirect")
+    normalizer = MacroNormalizer()
+
+    normalized = normalizer.normalize_block(block)
+
+    macros = {op.macro for op in normalized.operations}
+    assert macros == {"frame_access", "global_access"}
+    slots = {operand for op in normalized.operations for operand in op.operands}
+    assert "slot=0x10" in slots
+    assert "slot=0x20" in slots
+
+
+def test_summary_collects_macro_counts():
+    knowledge = build_knowledge()
+    tail_block = make_block([make_word(0, 0x29)], knowledge, category="call")
+    return_block = make_block([make_word(0, 0x30)], knowledge, category="return")
+    literal_block = make_block([make_word(0, 0x10), make_word(4, 0x10), make_word(8, 0x20)], knowledge, category="literal")
+
+    report = PipelineReport(blocks=(tail_block, return_block, literal_block))
+
+    normalizer = MacroNormalizer()
+    normalized_blocks = normalizer.normalize_report(report)
+    summary = normalizer.summarise(normalized_blocks)
+
+    assert isinstance(summary, IntermediateSummary)
+    assert summary.operation_counts["tail_dispatch"] == 1
+    assert summary.operation_counts["frame_return"] == 1
+    assert summary.operation_counts["tuple_build"] == 1
+    assert summary.block_count == 3
+    description = summary.describe()
+    assert "blocks=3" in description
+    assert "tail_dispatch:1" in description


### PR DESCRIPTION
## Summary
- add a MacroNormalizer that collapses pipeline blocks into canonical macro operations for tail dispatch, returns, literal builds, predicates, and indirect accesses
- expose the normalizer and its summary structure from the analyzer package
- cover the new behaviour with dedicated normalizer unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa2244430832fb75b0f9bbd2c449b