### PR TITLE
Add IR normalizer pipeline with macro signature passes

### DIFF
--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -3,7 +3,26 @@
 from .adb import SegmentDescriptor, SegmentIndex
 from .disassembler import Disassembler
 from .instruction import InstructionWord
-from .knowledge import KnowledgeBase
+from .knowledge import KnowledgeBase, OpcodeInfo
+from .ir import (
+    IRBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRIf,
+    IRLiteral,
+    IRLoad,
+    IRNode,
+    IRReturn,
+    IRSlot,
+    IRStore,
+    IRTestSetBranch,
+    MemSpace,
+    Normalizer,
+    NormalizerMetrics,
+    NormalizerResult,
+)
 from .mbc import MbcContainer, Segment
 
 __all__ = [
@@ -12,6 +31,24 @@ __all__ = [
     "InstructionWord",
     "Disassembler",
     "KnowledgeBase",
+    "OpcodeInfo",
     "MbcContainer",
     "Segment",
+    "IRNode",
+    "IRLiteral",
+    "IRCall",
+    "IRReturn",
+    "IRBuildArray",
+    "IRBuildMap",
+    "IRBuildTuple",
+    "IRIf",
+    "IRTestSetBranch",
+    "IRBlock",
+    "IRLoad",
+    "IRStore",
+    "IRSlot",
+    "MemSpace",
+    "Normalizer",
+    "NormalizerResult",
+    "NormalizerMetrics",
 ]

--- a/mbcdisasm/ir/__init__.py
+++ b/mbcdisasm/ir/__init__.py
@@ -1,0 +1,44 @@
+"""Convenience exports for the normalisation intermediate representation."""
+
+from .nodes import (
+    IRBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRIf,
+    IRLiteral,
+    IRLoad,
+    IRNode,
+    IRReturn,
+    IRSlot,
+    IRStore,
+    IRTestSetBranch,
+    MemSpace,
+)
+from .normalizer import Normalizer, NormalizerMetrics, NormalizerResult
+from .raw import RawBlock, RawInstruction, RawProgram, parse_stream
+
+__all__ = [
+    "IRBlock",
+    "IRBuildArray",
+    "IRBuildMap",
+    "IRBuildTuple",
+    "IRCall",
+    "IRIf",
+    "IRLiteral",
+    "IRLoad",
+    "IRNode",
+    "IRReturn",
+    "IRSlot",
+    "IRStore",
+    "IRTestSetBranch",
+    "MemSpace",
+    "Normalizer",
+    "NormalizerMetrics",
+    "NormalizerResult",
+    "RawInstruction",
+    "RawBlock",
+    "RawProgram",
+    "parse_stream",
+]

--- a/mbcdisasm/ir/nodes.py
+++ b/mbcdisasm/ir/nodes.py
@@ -1,0 +1,140 @@
+"""Intermediate representation nodes for the normalisation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Sequence, Tuple
+
+
+class MemSpace(Enum):
+    """Memory space classification for indirect accesses."""
+
+    FRAME = auto()
+    GLOBAL = auto()
+    CONST = auto()
+
+
+@dataclass(frozen=True)
+class IRNode:
+    """Base class for all intermediate representation nodes."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class IRLiteral(IRNode):
+    """A literal value pushed on to the stack."""
+
+    value: int
+    size: int = 1
+
+
+@dataclass(frozen=True)
+class IRBuildArray(IRNode):
+    """Build an array from literal elements."""
+
+    elements: Tuple[IRNode, ...]
+
+    @classmethod
+    def from_sequence(cls, elements: Sequence[IRNode]) -> "IRBuildArray":
+        return cls(tuple(elements))
+
+
+@dataclass(frozen=True)
+class IRBuildMap(IRNode):
+    """Build a map/dictionary from literal key/value pairs."""
+
+    pairs: Tuple[Tuple[IRNode, IRNode], ...]
+
+    @classmethod
+    def from_pairs(
+        cls, pairs: Sequence[Tuple[IRNode, IRNode]]
+    ) -> "IRBuildMap":
+        return cls(tuple(tuple(pair) for pair in pairs))
+
+
+@dataclass(frozen=True)
+class IRBuildTuple(IRNode):
+    """Build a tuple with positional semantics."""
+
+    elements: Tuple[IRNode, ...]
+
+    @classmethod
+    def from_sequence(cls, elements: Sequence[IRNode]) -> "IRBuildTuple":
+        return cls(tuple(elements))
+
+
+@dataclass(frozen=True)
+class IRCall(IRNode):
+    """Function or helper invocation."""
+
+    target: int
+    args: Tuple[IRNode, ...]
+    tail: bool = False
+
+    @classmethod
+    def from_args(
+        cls, target: int, args: Sequence[IRNode], *, tail: bool = False
+    ) -> "IRCall":
+        return cls(target=target, args=tuple(args), tail=tail)
+
+
+@dataclass(frozen=True)
+class IRReturn(IRNode):
+    """Return from the current routine with a fixed arity."""
+
+    arity: int
+
+
+@dataclass(frozen=True)
+class IRSlot:
+    """A typed slot within a memory space."""
+
+    space: MemSpace
+    index: int
+
+
+@dataclass(frozen=True)
+class IRLoad(IRNode):
+    """Load a value from an indirect slot."""
+
+    slot: IRSlot
+
+
+@dataclass(frozen=True)
+class IRStore(IRNode):
+    """Store a value into an indirect slot."""
+
+    slot: IRSlot
+    value: IRNode
+
+
+@dataclass(frozen=True)
+class IRIf(IRNode):
+    """Conditional branch based on an expression."""
+
+    predicate: IRNode
+    then_target: int
+    else_target: int
+
+
+@dataclass(frozen=True)
+class IRTestSetBranch(IRNode):
+    """A branch that assigns the predicate to a dedicated variable."""
+
+    var: str
+    expr: IRNode
+    then_target: int
+    else_target: int
+
+
+@dataclass(frozen=True)
+class IRBlock:
+    """A normalised basic block."""
+
+    nodes: Tuple[IRNode, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_nodes(cls, nodes: Sequence[IRNode]) -> "IRBlock":
+        return cls(nodes=tuple(nodes))

--- a/mbcdisasm/ir/normalizer.py
+++ b/mbcdisasm/ir/normalizer.py
@@ -1,0 +1,386 @@
+"""Normalisation pipeline that turns raw opcodes into IR nodes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import List, MutableSequence, Optional, Sequence, Tuple, Union
+
+from ..instruction import InstructionWord
+from ..knowledge import KnowledgeBase
+from .nodes import (
+    IRBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRIf,
+    IRLiteral,
+    IRLoad,
+    IRNode,
+    IRReturn,
+    IRSlot,
+    IRStore,
+    IRTestSetBranch,
+    MemSpace,
+)
+from .raw import RawInstruction, parse_stream
+
+
+@dataclass(frozen=True)
+class NormalizerMetrics:
+    """Summary statistics for a normalisation run."""
+
+    calls: int
+    tail_calls: int
+    returns: int
+    aggregates: int
+    testset_branches: int
+    if_branches: int
+    loads: int
+    stores: int
+    reduce_replaced: int
+    raw_remaining: int
+
+
+@dataclass(frozen=True)
+class NormalizerResult:
+    """Final product of a normalisation pass."""
+
+    blocks: Tuple[IRBlock, ...]
+    metrics: NormalizerMetrics
+
+
+Token = Union[IRNode, RawInstruction]
+
+
+class Normalizer:
+    """Build the canonical IR described by the macro signature instructions."""
+
+    def __init__(self, knowledge: KnowledgeBase) -> None:
+        self.knowledge = knowledge
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def normalise(
+        self, words: Sequence[InstructionWord]
+    ) -> NormalizerResult:
+        program = parse_stream(words, self.knowledge)
+        blocks: List[IRBlock] = []
+        metrics_counter = Counter()
+
+        for block in program.blocks:
+            tokens: List[Token] = [self._initial_token(inst) for inst in block.instructions]
+            tokens = self._merge_calls(tokens, metrics_counter)
+            tokens, reduced = self._collapse_literals(tokens, metrics_counter)
+            metrics_counter["reduce_replaced"] += reduced
+            tokens = self._lift_branches(tokens, metrics_counter)
+            tokens = self._map_indirect(tokens, metrics_counter)
+            ir_nodes = [token for token in tokens if isinstance(token, IRNode)]
+            metrics_counter["raw_remaining"] += sum(
+                1 for token in tokens if not isinstance(token, IRNode)
+            )
+            blocks.append(IRBlock.from_nodes(ir_nodes))
+
+        metrics = NormalizerMetrics(
+            calls=metrics_counter.get("calls", 0),
+            tail_calls=metrics_counter.get("tail_calls", 0),
+            returns=metrics_counter.get("returns", 0),
+            aggregates=metrics_counter.get("aggregates", 0),
+            testset_branches=metrics_counter.get("testset_branches", 0),
+            if_branches=metrics_counter.get("if_branches", 0),
+            loads=metrics_counter.get("loads", 0),
+            stores=metrics_counter.get("stores", 0),
+            reduce_replaced=metrics_counter.get("reduce_replaced", 0),
+            raw_remaining=metrics_counter.get("raw_remaining", 0),
+        )
+        return NormalizerResult(blocks=tuple(blocks), metrics=metrics)
+
+    # ------------------------------------------------------------------
+    # token initialisation
+    # ------------------------------------------------------------------
+    def _initial_token(self, instruction: RawInstruction) -> Token:
+        if instruction.category and instruction.category.lower() in {"literal", "push"}:
+            return IRLiteral(instruction.operand)
+        return instruction
+
+    # ------------------------------------------------------------------
+    # call/return pass
+    # ------------------------------------------------------------------
+    def _merge_calls(
+        self, tokens: Sequence[Token], metrics: Counter
+    ) -> List[Token]:
+        result: List[Token] = []
+        idx = 0
+        while idx < len(tokens):
+            token = tokens[idx]
+            if isinstance(token, RawInstruction) and self._is_call_opcode(token):
+                args = self._collect_arguments(result, token)
+                call = IRCall.from_args(token.operand, args, tail=False)
+                metrics["calls"] += 1
+                tail, consumed, ret = self._maybe_tail_return(tokens, idx + 1, metrics)
+                if tail:
+                    call = IRCall.from_args(token.operand, args, tail=True)
+                result.append(call)
+                if ret is not None:
+                    result.append(ret)
+                idx += consumed
+                continue
+            if isinstance(token, RawInstruction) and self._is_return(token):
+                arity = self._return_arity(token)
+                metrics["returns"] += 1
+                result.append(IRReturn(arity))
+                idx += 1
+                continue
+            result.append(token)
+            idx += 1
+        return result
+
+    def _collect_arguments(
+        self, stack: MutableSequence[Token], token: RawInstruction
+    ) -> List[IRNode]:
+        arg_count = self._argument_count(token)
+        args: List[IRNode] = []
+        if arg_count == 0:
+            while stack:
+                candidate = stack[-1]
+                if not isinstance(candidate, IRNode) or not self._is_argument_node(candidate):
+                    break
+                args.append(candidate)
+                stack.pop()
+            args.reverse()
+            return args
+        while stack and arg_count != 0:
+            candidate = stack[-1]
+            if not isinstance(candidate, IRNode) or not self._is_argument_node(candidate):
+                break
+            args.append(candidate)
+            stack.pop()
+            arg_count -= 1
+        args.reverse()
+        return args
+
+    def _is_argument_node(self, node: IRNode) -> bool:
+        return isinstance(
+            node,
+            (
+                IRLiteral,
+                IRBuildArray,
+                IRBuildMap,
+                IRBuildTuple,
+                IRLoad,
+            ),
+        )
+
+    def _argument_count(self, token: RawInstruction) -> int:
+        if token.info is not None:
+            count = token.info.attributes.get("arg_count") if token.info.attributes else None
+            if isinstance(count, int):
+                return max(0, count)
+        if token.stack_delta < 0:
+            return abs(token.stack_delta)
+        return 0
+
+    def _maybe_tail_return(
+        self, tokens: Sequence[Token], start: int, metrics: Counter
+    ) -> Tuple[bool, int, Optional[IRReturn]]:
+        idx = start
+        consumed = 1
+        tail = False
+        ret: Optional[IRReturn] = None
+        while idx < len(tokens):
+            token = tokens[idx]
+            if isinstance(token, RawInstruction) and self._is_return(token):
+                arity = self._return_arity(token)
+                metrics["returns"] += 1
+                metrics["tail_calls"] += 1
+                tail = True
+                ret = IRReturn(arity)
+                consumed = idx - start + 2
+                break
+            if isinstance(token, RawInstruction) and token.category == "service":
+                idx += 1
+                continue
+            break
+        return tail, consumed, ret
+
+    def _is_call_opcode(self, token: RawInstruction) -> bool:
+        mnemonic = token.mnemonic.lower()
+        if "call" in mnemonic:
+            return True
+        if token.control_flow == "call":
+            return True
+        return False
+
+    def _return_arity(self, token: RawInstruction) -> int:
+        if token.info is not None and token.info.attributes:
+            arity = token.info.attributes.get("return_arity")
+            if isinstance(arity, int):
+                return max(0, arity)
+        if token.stack_delta < 0:
+            return abs(token.stack_delta)
+        return 0
+
+    def _is_return(self, token: RawInstruction) -> bool:
+        mnemonic = token.mnemonic.lower()
+        if mnemonic.startswith("return"):
+            return True
+        return token.control_flow == "return"
+
+    # ------------------------------------------------------------------
+    # literal collapse pass
+    # ------------------------------------------------------------------
+    def _collapse_literals(
+        self, tokens: Sequence[Token], metrics: Counter
+    ) -> Tuple[List[Token], int]:
+        result: List[Token] = []
+        idx = 0
+        replaced = 0
+        while idx < len(tokens):
+            token = tokens[idx]
+            if isinstance(token, IRLiteral):
+                literals: List[IRLiteral] = [token]
+                j = idx + 1
+                while j < len(tokens) and isinstance(tokens[j], IRLiteral):
+                    literals.append(tokens[j])
+                    j += 1
+                reduce_tokens: List[RawInstruction] = []
+                while j < len(tokens):
+                    candidate = tokens[j]
+                    if isinstance(candidate, RawInstruction) and self._is_reduce(candidate):
+                        reduce_tokens.append(candidate)
+                        j += 1
+                        continue
+                    break
+                if reduce_tokens:
+                    aggregate = self._build_aggregate(literals, reduce_tokens)
+                    result.append(aggregate)
+                    metrics["aggregates"] += 1
+                    replaced += len(reduce_tokens)
+                    idx = j
+                    continue
+            result.append(token)
+            idx += 1
+        return result, replaced
+
+    def _is_reduce(self, token: RawInstruction) -> bool:
+        if token.category and token.category.lower() == "reduce":
+            return True
+        return token.mnemonic.lower().startswith("reduce")
+
+    def _build_aggregate(
+        self, literals: Sequence[IRLiteral], reduces: Sequence[RawInstruction]
+    ) -> IRNode:
+        primary = reduces[0].mnemonic.lower()
+        if "pair" in primary and len(literals) % 2 == 0:
+            pairs = []
+            for idx in range(0, len(literals), 2):
+                pairs.append((literals[idx], literals[idx + 1]))
+            return IRBuildMap.from_pairs(pairs)
+        if len(literals) == len(reduces) + 1:
+            return IRBuildArray.from_sequence(literals)
+        return IRBuildTuple.from_sequence(literals)
+
+    # ------------------------------------------------------------------
+    # branch lifting pass
+    # ------------------------------------------------------------------
+    def _lift_branches(
+        self, tokens: Sequence[Token], metrics: Counter
+    ) -> List[Token]:
+        result: List[Token] = []
+        idx = 0
+        while idx < len(tokens):
+            token = tokens[idx]
+            if isinstance(token, RawInstruction) and self._is_testset(token):
+                expr = self._pop_last_node(result)
+                var = token.info.attributes.get("assign") if token.info and token.info.attributes else None
+                name = str(var or f"t{token.operand:04X}")
+                branch = IRTestSetBranch(
+                    var=name,
+                    expr=expr or IRLiteral(0),
+                    then_target=self._branch_target(token, "then"),
+                    else_target=self._branch_target(token, "else"),
+                )
+                metrics["testset_branches"] += 1
+                result.append(branch)
+                idx += 1
+                continue
+            if isinstance(token, RawInstruction) and self._is_if_branch(token):
+                expr = self._pop_last_node(result)
+                branch = IRIf(
+                    predicate=expr or IRLiteral(0),
+                    then_target=self._branch_target(token, "then"),
+                    else_target=self._branch_target(token, "else"),
+                )
+                metrics["if_branches"] += 1
+                result.append(branch)
+                idx += 1
+                continue
+            result.append(token)
+            idx += 1
+        return result
+
+    def _is_testset(self, token: RawInstruction) -> bool:
+        mnemonic = token.mnemonic.lower()
+        if "testset" in mnemonic or mnemonic.startswith("test_"):
+            return True
+        return token.category == "testset"
+
+    def _is_if_branch(self, token: RawInstruction) -> bool:
+        mnemonic = token.mnemonic.lower()
+        if mnemonic.startswith("if") or token.control_flow == "branch":
+            return True
+        return False
+
+    def _branch_target(self, token: RawInstruction, key: str) -> int:
+        if token.info and token.info.attributes:
+            value = token.info.attributes.get(f"{key}_target")
+            if isinstance(value, int):
+                return value
+        return token.operand
+
+    def _pop_last_node(self, stack: MutableSequence[Token]) -> Optional[IRNode]:
+        if stack and isinstance(stack[-1], IRNode):
+            node = stack.pop()
+            assert isinstance(node, IRNode)
+            return node
+        return None
+
+    # ------------------------------------------------------------------
+    # indirect mapping pass
+    # ------------------------------------------------------------------
+    def _map_indirect(
+        self, tokens: Sequence[Token], metrics: Counter
+    ) -> List[Token]:
+        result: List[Token] = []
+        for token in tokens:
+            if isinstance(token, RawInstruction) and self._is_indirect(token):
+                slot = IRSlot(space=self._classify_space(token.operand), index=token.operand)
+                if self._is_store(token):
+                    value = self._pop_last_node(result) or IRLiteral(0)
+                    result.append(IRStore(slot=slot, value=value))
+                    metrics["stores"] += 1
+                else:
+                    result.append(IRLoad(slot=slot))
+                    metrics["loads"] += 1
+                continue
+            result.append(token)
+        return result
+
+    def _is_indirect(self, token: RawInstruction) -> bool:
+        mnemonic = token.mnemonic.lower()
+        if "indirect" in mnemonic:
+            return True
+        return token.category in {"indirect", "indirect_load", "indirect_store"}
+
+    def _is_store(self, token: RawInstruction) -> bool:
+        mnemonic = token.mnemonic.lower()
+        return "store" in mnemonic or token.category == "indirect_store"
+
+    def _classify_space(self, operand: int) -> MemSpace:
+        if operand < 0x100:
+            return MemSpace.FRAME
+        if operand < 0x8000:
+            return MemSpace.GLOBAL
+        return MemSpace.CONST

--- a/mbcdisasm/ir/raw.py
+++ b/mbcdisasm/ir/raw.py
@@ -1,0 +1,102 @@
+"""Raw instruction stream parsing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from ..instruction import InstructionWord
+from ..knowledge import KnowledgeBase, OpcodeInfo
+
+
+@dataclass(frozen=True)
+class RawInstruction:
+    """Parsed opcode description with metadata for normalisation passes."""
+
+    word: InstructionWord
+    mnemonic: str
+    opcode: int
+    mode: int
+    operand: int
+    info: Optional[OpcodeInfo]
+    stack_delta: int
+    category: Optional[str]
+    control_flow: Optional[str]
+    note: Optional[str] = None
+
+    def label(self) -> str:
+        return f"{self.opcode:02X}:{self.mode:02X}"
+
+
+@dataclass(frozen=True)
+class RawBlock:
+    """Basic block consisting of raw instructions."""
+
+    instructions: Tuple[RawInstruction, ...]
+
+    @classmethod
+    def from_instructions(
+        cls, instructions: Sequence[RawInstruction]
+    ) -> "RawBlock":
+        return cls(tuple(instructions))
+
+
+@dataclass(frozen=True)
+class RawProgram:
+    """Container for the parsed instruction stream."""
+
+    blocks: Tuple[RawBlock, ...]
+
+    @classmethod
+    def from_blocks(cls, blocks: Sequence[RawBlock]) -> "RawProgram":
+        return cls(tuple(blocks))
+
+
+CONTROL_FLOW_TERMINALS = {"return", "tail", "jump"}
+
+
+def parse_stream(
+    words: Sequence[InstructionWord], knowledge: KnowledgeBase
+) -> RawProgram:
+    """Convert raw instructions to :class:`RawInstruction` entries."""
+
+    raw_instructions: List[RawInstruction] = []
+    for word in words:
+        label = word.label()
+        info = knowledge.lookup(label)
+        mnemonic = info.mnemonic if info is not None else f"op_{label}"
+        stack_delta = info.stack_effect() if info is not None else 0
+        category = info.category if info is not None else None
+        control = info.control_flow if info is not None else None
+        raw_instructions.append(
+            RawInstruction(
+                word=word,
+                mnemonic=mnemonic,
+                opcode=word.opcode,
+                mode=word.mode,
+                operand=word.operand,
+                info=info,
+                stack_delta=stack_delta or 0,
+                category=category,
+                control_flow=control,
+            )
+        )
+
+    blocks: List[List[RawInstruction]] = [[]]
+    for inst in raw_instructions:
+        blocks[-1].append(inst)
+        if _terminates_block(inst):
+            blocks.append([])
+    if blocks and not blocks[-1]:
+        blocks.pop()
+
+    return RawProgram.from_blocks(RawBlock.from_instructions(block) for block in blocks)
+
+
+def _terminates_block(inst: RawInstruction) -> bool:
+    if inst.control_flow in CONTROL_FLOW_TERMINALS:
+        return True
+    mnemonic = inst.mnemonic.lower()
+    if mnemonic in {"return", "return_values"}:
+        return True
+    return False

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,178 @@
+from mbcdisasm import (
+    InstructionWord,
+    KnowledgeBase,
+    Normalizer,
+    OpcodeInfo,
+)
+from mbcdisasm.ir import (
+    IRBuildMap,
+    IRCall,
+    IRLiteral,
+    IRLoad,
+    IRReturn,
+    IRStore,
+    IRTestSetBranch,
+    MemSpace,
+)
+
+
+def make_word(offset: int, opcode: int, mode: int = 0, operand: int = 0) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset, raw)
+
+
+def build_knowledge(entries):
+    return KnowledgeBase(entries)
+
+
+def test_tail_call_is_collapsed_with_return():
+    knowledge = build_knowledge(
+        {
+            "10:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "11:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "20:00": OpcodeInfo(
+                mnemonic="tailcall_dispatch",
+                control_flow="call",
+                category="call",
+                attributes={"arg_count": 2},
+            ),
+            "30:00": OpcodeInfo(
+                mnemonic="return_values",
+                control_flow="return",
+                category="return",
+                attributes={"return_arity": 1},
+            ),
+        }
+    )
+    normalizer = Normalizer(knowledge)
+    words = [
+        make_word(0, 0x10),
+        make_word(4, 0x11),
+        make_word(8, 0x20, operand=3),
+        make_word(12, 0x30),
+    ]
+    result = normalizer.normalise(words)
+    nodes = result.blocks[0].nodes
+    assert isinstance(nodes[0], IRCall)
+    assert nodes[0].tail is True
+    assert len(nodes[0].args) == 2
+    assert isinstance(nodes[1], IRReturn)
+    assert nodes[1].arity == 1
+    assert result.metrics.calls == 1
+    assert result.metrics.tail_calls == 1
+    assert result.metrics.returns == 1
+
+
+def test_literal_reduce_chain_collapses_to_map():
+    knowledge = build_knowledge(
+        {
+            "10:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "11:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "12:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "13:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "20:00": OpcodeInfo(mnemonic="reduce_pair", category="reduce", stack_delta=-1),
+        }
+    )
+    normalizer = Normalizer(knowledge)
+    words = [
+        make_word(0, 0x10, operand=1),
+        make_word(4, 0x11, operand=2),
+        make_word(8, 0x12, operand=3),
+        make_word(12, 0x13, operand=4),
+        make_word(16, 0x20),
+        make_word(20, 0x20),
+    ]
+    result = normalizer.normalise(words)
+    nodes = result.blocks[0].nodes
+    assert len(nodes) == 1
+    aggregate = nodes[0]
+    assert isinstance(aggregate, IRBuildMap)
+    assert len(aggregate.pairs) == 2
+    assert all(isinstance(pair[0], IRLiteral) for pair in aggregate.pairs)
+    assert result.metrics.aggregates == 1
+    assert result.metrics.reduce_replaced == 2
+
+
+def test_testset_branch_is_lifted():
+    knowledge = build_knowledge(
+        {
+            "10:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "20:00": OpcodeInfo(
+                mnemonic="testset_branch",
+                category="testset",
+                control_flow="branch",
+                attributes={"assign": "flag", "then_target": 0x100, "else_target": 0x200},
+            ),
+        }
+    )
+    normalizer = Normalizer(knowledge)
+    words = [
+        make_word(0, 0x10, operand=1),
+        make_word(4, 0x20, operand=0x300),
+    ]
+    result = normalizer.normalise(words)
+    nodes = result.blocks[0].nodes
+    assert isinstance(nodes[0], IRTestSetBranch)
+    assert nodes[0].var == "flag"
+    assert isinstance(nodes[0].expr, IRLiteral)
+    assert nodes[0].then_target == 0x100
+    assert nodes[0].else_target == 0x200
+    assert result.metrics.testset_branches == 1
+
+
+def test_indirect_accesses_are_mapped():
+    knowledge = build_knowledge(
+        {
+            "10:00": OpcodeInfo(mnemonic="literal", category="literal", stack_delta=1),
+            "20:00": OpcodeInfo(mnemonic="indirect_store", category="indirect_store"),
+            "21:00": OpcodeInfo(mnemonic="indirect_load", category="indirect_load"),
+        }
+    )
+    normalizer = Normalizer(knowledge)
+    words = [
+        make_word(0, 0x10, operand=7),
+        make_word(4, 0x20, operand=0x10),
+        make_word(8, 0x21, operand=0x4000),
+    ]
+    result = normalizer.normalise(words)
+    nodes = result.blocks[0].nodes
+    assert isinstance(nodes[0], IRStore)
+    assert nodes[0].slot.space is MemSpace.FRAME
+    assert isinstance(nodes[0].value, IRLiteral)
+    assert isinstance(nodes[1], IRLoad)
+    assert nodes[1].slot.space is MemSpace.GLOBAL
+    assert result.metrics.stores == 1
+    assert result.metrics.loads == 1
+
+
+def test_unknown_instructions_are_counted():
+    knowledge = build_knowledge({})
+    normalizer = Normalizer(knowledge)
+    words = [
+        make_word(0, 0xFF),
+        make_word(4, 0x10, operand=1),
+    ]
+    result = normalizer.normalise(words)
+    assert result.metrics.raw_remaining >= 1
+    assert result.metrics.calls == 0
+
+
+def test_plain_return_is_exposed():
+    knowledge = build_knowledge(
+        {
+            "30:00": OpcodeInfo(
+                mnemonic="return_values",
+                control_flow="return",
+                category="return",
+                attributes={"return_arity": 2},
+            ),
+        }
+    )
+    normalizer = Normalizer(knowledge)
+    words = [make_word(0, 0x30)]
+    result = normalizer.normalise(words)
+    nodes = result.blocks[0].nodes
+    assert len(nodes) == 1
+    assert isinstance(nodes[0], IRReturn)
+    assert nodes[0].arity == 2
+    assert result.metrics.returns == 1


### PR DESCRIPTION
## Summary
- introduce dataclasses for the new intermediate representation, covering calls, returns, aggregates, branches, and indirect slots
- add a multi-pass normaliser that parses opcode streams, folds calls/returns, collapses literal-reduction chains, lifts branch forms, and maps indirect accesses
- expose the normaliser in the package exports and add unit tests that exercise tail calls, aggregate construction, branch lifting, and memory mapping

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dff3aca054832f9ef8efe2eb972d29