### PR TITLE
Add IR normalizer pipeline and integration

### DIFF
--- a/mbc_disasm.py
+++ b/mbc_disasm.py
@@ -69,7 +69,15 @@ def main() -> None:
         segment_indices=resolve_segments(args),
         max_instructions=args.max_instr,
     )
+    ir_output = output_path.with_suffix(".ir.txt")
+    disassembler.write_ir(
+        container,
+        ir_output,
+        segment_indices=resolve_segments(args),
+        max_instructions=args.max_instr,
+    )
     print(f"disassembly written to {output_path}")
+    print(f"ir written to {ir_output}")
     if summary:
         print(
             "analysis summary: "

--- a/mbcdisasm/ir/__init__.py
+++ b/mbcdisasm/ir/__init__.py
@@ -1,0 +1,42 @@
+"""Intermediate representation builder for MBC scripts."""
+
+from .model import (
+    IRBasicBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRIf,
+    IRLiteral,
+    IRLoad,
+    IRProgram,
+    IRReturn,
+    IRSlot,
+    IRStore,
+    IRTemp,
+    IRTestSetBranch,
+    MemSpace,
+    NormalizerMetrics,
+)
+from .pipeline import build_segment_ir, render_program
+
+__all__ = [
+    "IRBasicBlock",
+    "IRBuildArray",
+    "IRBuildMap",
+    "IRBuildTuple",
+    "IRCall",
+    "IRIf",
+    "IRLiteral",
+    "IRLoad",
+    "IRProgram",
+    "IRReturn",
+    "IRSlot",
+    "IRStore",
+    "IRTemp",
+    "IRTestSetBranch",
+    "MemSpace",
+    "NormalizerMetrics",
+    "build_segment_ir",
+    "render_program",
+]

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -1,0 +1,219 @@
+"""Data structures for the normalised intermediate representation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Iterable, List, Sequence, Tuple
+
+
+class MemSpace(Enum):
+    """Addressing domains recognised by the normaliser."""
+
+    FRAME = auto()
+    GLOBAL = auto()
+    CONST = auto()
+
+
+@dataclass(frozen=True)
+class IRTemp:
+    """Named temporary produced by IR operations."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class IRLiteral:
+    """Literal value created by the normaliser."""
+
+    value: int
+
+    def render(self) -> str:
+        return f"#{self.value}"
+
+
+@dataclass(frozen=True)
+class IRSlot:
+    """Reference to an addressable VM slot."""
+
+    space: MemSpace
+    index: int
+
+    def render(self) -> str:
+        space = self.space.name.lower()
+        return f"{space}[0x{self.index:04X}]"
+
+
+class IRNode:
+    """Base class for IR operations to ease type checking."""
+
+
+@dataclass
+class IRBuildArray(IRNode):
+    result: IRTemp
+    elements: Sequence[object]
+
+    def render(self) -> str:
+        values = ", ".join(_render_value(value) for value in self.elements)
+        return f"{self.result.name} = build_array([{values}])"
+
+
+@dataclass
+class IRBuildTuple(IRNode):
+    result: IRTemp
+    elements: Sequence[object]
+
+    def render(self) -> str:
+        values = ", ".join(_render_value(value) for value in self.elements)
+        return f"{self.result.name} = build_tuple({values})"
+
+
+@dataclass
+class IRBuildMap(IRNode):
+    result: IRTemp
+    items: Sequence[Tuple[object, object]]
+
+    def render(self) -> str:
+        parts = []
+        for key, value in self.items:
+            parts.append(f"{_render_value(key)}: {_render_value(value)}")
+        inside = ", ".join(parts)
+        return f"{self.result.name} = build_map({{{inside}}})"
+
+
+@dataclass
+class IRCall(IRNode):
+    target: int
+    args: Sequence[object]
+    result: IRTemp | None
+    tail: bool = False
+
+    def render(self) -> str:
+        args = ", ".join(_render_value(arg) for arg in self.args)
+        prefix = "tailcall" if self.tail else "call"
+        if self.result is None:
+            return f"{prefix} fn@0x{self.target:04X}({args})"
+        return f"{self.result.name} = {prefix} fn@0x{self.target:04X}({args})"
+
+
+@dataclass
+class IRReturn(IRNode):
+    values: Sequence[object]
+
+    def render(self) -> str:
+        payload = ", ".join(_render_value(value) for value in self.values)
+        return f"return {payload}"
+
+
+@dataclass
+class IRIf(IRNode):
+    predicate: object
+    then_target: str
+    else_target: str
+
+    def render(self) -> str:
+        return (
+            f"if {_render_value(self.predicate)} then goto {self.then_target} "
+            f"else goto {self.else_target}"
+        )
+
+
+@dataclass
+class IRTestSetBranch(IRNode):
+    target: IRTemp
+    expression: object
+    then_target: str
+    else_target: str
+
+    def render(self) -> str:
+        expr = _render_value(self.expression)
+        return (
+            f"{self.target.name} = testset {expr} ? goto {self.then_target} "
+            f": goto {self.else_target}"
+        )
+
+
+@dataclass
+class IRLoad(IRNode):
+    result: IRTemp
+    slot: IRSlot
+
+    def render(self) -> str:
+        return f"{self.result.name} = load {self.slot.render()}"
+
+
+@dataclass
+class IRStore(IRNode):
+    slot: IRSlot
+    value: object
+
+    def render(self) -> str:
+        return f"store {self.slot.render()} <- {_render_value(self.value)}"
+
+
+@dataclass
+class IRBasicBlock:
+    label: str
+    operations: List[IRNode] = field(default_factory=list)
+
+    def render(self) -> List[str]:
+        lines = [f"block {self.label}:"]
+        for op in self.operations:
+            lines.append(f"  {op.render()}")
+        return lines
+
+
+@dataclass
+class NormalizerMetrics:
+    calls: int = 0
+    tail_calls: int = 0
+    returns: int = 0
+    aggregates: int = 0
+    testset_branches: int = 0
+    if_branches: int = 0
+    loads: int = 0
+    stores: int = 0
+    reduce_replaced: int = 0
+    raw_remaining: int = 0
+
+    def merge(self, other: "NormalizerMetrics") -> None:
+        for field in ("calls", "tail_calls", "returns", "aggregates", "testset_branches", "if_branches", "loads", "stores", "reduce_replaced", "raw_remaining"):
+            setattr(self, field, getattr(self, field) + getattr(other, field))
+
+    def render(self) -> List[str]:
+        return [
+            "metrics:",
+            f"  calls={self.calls}",
+            f"  tail_calls={self.tail_calls}",
+            f"  returns={self.returns}",
+            f"  aggregates={self.aggregates}",
+            f"  testset_branches={self.testset_branches}",
+            f"  if_branches={self.if_branches}",
+            f"  loads={self.loads}",
+            f"  stores={self.stores}",
+            f"  reduce_replaced={self.reduce_replaced}",
+            f"  raw_remaining={self.raw_remaining}",
+        ]
+
+
+@dataclass
+class IRProgram:
+    blocks: Sequence[IRBasicBlock]
+    metrics: NormalizerMetrics
+
+    def render(self) -> List[str]:
+        lines: List[str] = []
+        lines.extend(self.metrics.render())
+        for block in self.blocks:
+            lines.extend(block.render())
+        return lines
+
+
+def _render_value(value: object) -> str:
+    if isinstance(value, IRTemp):
+        return value.name
+    if isinstance(value, IRLiteral):
+        return value.render()
+    if isinstance(value, IRSlot):
+        return value.render()
+    return str(value)

--- a/mbcdisasm/ir/normalizer.py
+++ b/mbcdisasm/ir/normalizer.py
@@ -1,0 +1,291 @@
+"""Normalisation pipeline turning raw instruction blocks into IR blocks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from ..analyzer.instruction_profile import InstructionKind
+from .model import (
+    IRBasicBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRIf,
+    IRLiteral,
+    IRLoad,
+    IRReturn,
+    IRSlot,
+    IRStore,
+    IRTemp,
+    IRTestSetBranch,
+    MemSpace,
+    NormalizerMetrics,
+)
+from .raw import RawBasicBlock, RawInstruction
+
+
+@dataclass
+class _Event:
+    kind: str
+    instruction: RawInstruction
+    data: dict
+
+
+class BlockNormaliser:
+    """Convert :class:`RawBasicBlock` instances into :class:`IRBasicBlock`."""
+
+    def __init__(self, block: RawBasicBlock) -> None:
+        self.block = block
+        self.metrics = NormalizerMetrics()
+        self.events: List[_Event] = []
+        self._temp_counter = 0
+
+    def run(self) -> IRBasicBlock:
+        self._build_events()
+        self._fold_literal_windows()
+        operations: List = []
+        stack: List[object] = []
+
+        for event in self.events:
+            handler = getattr(self, f"_handle_{event.kind}", None)
+            if handler is None:
+                self.metrics.raw_remaining += 1
+                continue
+            produced = handler(event, stack)
+            if produced is None:
+                continue
+            if isinstance(produced, list):
+                operations.extend(produced)
+            else:
+                operations.append(produced)
+
+        return IRBasicBlock(label=self.block.label, operations=operations)
+
+    def _build_events(self) -> None:
+        instructions = self.block.instructions
+        consumed: set[int] = set()
+        for idx, instruction in enumerate(instructions):
+            if idx in consumed:
+                continue
+            mnemonic = instruction.mnemonic
+            profile = instruction.profile
+            if mnemonic == "push_literal":
+                self.events.append(_Event("literal", instruction, {"value": instruction.profile.operand}))
+                continue
+            if mnemonic == "reduce_pair":
+                self.events.append(_Event("reduce", instruction, {}))
+                continue
+            if mnemonic == "tailcall_dispatch":
+                tail_data = {"target": instruction.profile.operand, "stack_delta": instruction.stack_delta, "return_count": None}
+                lookahead = idx + 1
+                while lookahead < len(instructions):
+                    candidate = instructions[lookahead]
+                    if candidate.mnemonic == "return_values":
+                        tail_data["return_count"] = candidate.profile.operand & 0xFF
+                        consumed.add(lookahead)
+                        break
+                    if candidate.stack_delta != 0:
+                        break
+                    lookahead += 1
+                self.events.append(_Event("tailcall", instruction, tail_data))
+                continue
+            if profile.kind is InstructionKind.CALL:
+                payload = {"target": instruction.profile.operand, "stack_delta": instruction.stack_delta}
+                self.events.append(_Event("call", instruction, payload))
+                continue
+            if mnemonic == "return_values" or profile.kind is InstructionKind.RETURN:
+                count = instruction.profile.operand & 0xFF
+                self.events.append(_Event("return", instruction, {"count": count}))
+                continue
+            if mnemonic == "testset_branch":
+                operand = instruction.profile.operand
+                self.events.append(
+                    _Event(
+                        "testset",
+                        instruction,
+                        {"operand": operand, "successors": self.block.successors},
+                    )
+                )
+                continue
+            if mnemonic == "test_branch" or profile.kind is InstructionKind.BRANCH:
+                operand = instruction.profile.operand
+                self.events.append(
+                    _Event(
+                        "if_branch",
+                        instruction,
+                        {"operand": operand, "successors": self.block.successors},
+                    )
+                )
+                continue
+            if profile.kind in {InstructionKind.INDIRECT, InstructionKind.INDIRECT_LOAD, InstructionKind.INDIRECT_STORE}:
+                self.events.append(
+                    _Event(
+                        "indirect",
+                        instruction,
+                        {"operand": instruction.profile.operand, "delta": instruction.stack_delta},
+                    )
+                )
+                continue
+            self.events.append(_Event("raw", instruction, {}))
+
+    def _fold_literal_windows(self) -> None:
+        folded: List[_Event] = []
+        idx = 0
+        while idx < len(self.events):
+            event = self.events[idx]
+            if event.kind != "literal":
+                folded.append(event)
+                idx += 1
+                continue
+            literals: List[_Event] = []
+            j = idx
+            while j < len(self.events) and self.events[j].kind == "literal":
+                literals.append(self.events[j])
+                j += 1
+            k = j
+            reduce_count = 0
+            while k < len(self.events) and self.events[k].kind == "reduce":
+                reduce_count += 1
+                k += 1
+            aggregate_event = self._try_fold_literals(literals, reduce_count)
+            if aggregate_event:
+                folded.append(aggregate_event)
+                idx = j + reduce_count
+                self.metrics.aggregates += 1
+                self.metrics.reduce_replaced += reduce_count
+            else:
+                folded.extend(literals)
+                idx = j
+        self.events = folded
+
+    def _try_fold_literals(self, literals: Sequence[_Event], reduce_count: int) -> Optional[_Event]:
+        if not literals or reduce_count == 0:
+            return None
+        values = [IRLiteral(evt.data["value"]) for evt in literals]
+        if reduce_count * 2 == len(literals):
+            items = []
+            for idx in range(0, len(values), 2):
+                items.append((values[idx], values[idx + 1]))
+            temp = self._new_temp()
+            return _Event("aggregate_map", literals[0].instruction, {"items": items, "temp": temp})
+        if reduce_count == len(literals) - 1:
+            temp = self._new_temp()
+            return _Event("aggregate_array", literals[0].instruction, {"values": values, "temp": temp})
+        return None
+
+    def _new_temp(self) -> IRTemp:
+        name = f"t{self._temp_counter}"
+        self._temp_counter += 1
+        return IRTemp(name)
+
+    def _handle_literal(self, event: _Event, stack: List[object]):
+        literal = IRLiteral(event.data["value"])
+        stack.append(literal)
+        return None
+
+    def _handle_aggregate_map(self, event: _Event, stack: List[object]):
+        items = event.data["items"]
+        result = event.data["temp"]
+        stack.append(result)
+        return IRBuildMap(result=result, items=items)
+
+    def _handle_aggregate_array(self, event: _Event, stack: List[object]):
+        values = event.data["values"]
+        result = event.data["temp"]
+        stack.append(result)
+        return IRBuildArray(result=result, elements=values)
+
+    def _handle_tailcall(self, event: _Event, stack: List[object]):
+        arg_count = max(0, -event.data.get("stack_delta", 0))
+        args = _pop_args(stack, arg_count)
+        result = None
+        self.metrics.tail_calls += 1
+        self.metrics.calls += 1
+        call_op = IRCall(target=event.data["target"], args=args, result=result, tail=True)
+        operations = [call_op]
+        return_count = event.data.get("return_count")
+        if return_count is not None:
+            returns = _pop_args(stack, return_count)
+            self.metrics.returns += 1
+            operations.append(IRReturn(values=returns))
+        return operations
+
+    def _handle_call(self, event: _Event, stack: List[object]):
+        arg_count = max(0, -event.data.get("stack_delta", 0))
+        args = _pop_args(stack, arg_count)
+        result = self._new_temp()
+        stack.append(result)
+        self.metrics.calls += 1
+        return IRCall(target=event.data["target"], args=args, result=result, tail=False)
+
+    def _handle_return(self, event: _Event, stack: List[object]):
+        count = event.data.get("count", 0)
+        values = _pop_args(stack, count)
+        self.metrics.returns += 1
+        return IRReturn(values=values)
+
+    def _handle_testset(self, event: _Event, stack: List[object]):
+        if stack:
+            expr = stack.pop()
+        else:
+            expr = IRLiteral(0)
+        temp = self._new_temp()
+        then_target, else_target = _branch_targets(self.block.successors)
+        node = IRTestSetBranch(target=temp, expression=expr, then_target=then_target, else_target=else_target)
+        stack.append(temp)
+        self.metrics.testset_branches += 1
+        return node
+
+    def _handle_if_branch(self, event: _Event, stack: List[object]):
+        predicate = stack.pop() if stack else IRLiteral(0)
+        then_target, else_target = _branch_targets(self.block.successors)
+        self.metrics.if_branches += 1
+        return IRIf(predicate=predicate, then_target=then_target, else_target=else_target)
+
+    def _handle_indirect(self, event: _Event, stack: List[object]):
+        operand = event.data["operand"]
+        slot = IRSlot(space=_classify_space(operand), index=operand)
+        delta = event.data["delta"]
+        if delta >= 0:
+            temp = self._new_temp()
+            stack.append(temp)
+            self.metrics.loads += 1
+            return IRLoad(result=temp, slot=slot)
+        value = stack.pop() if stack else IRLiteral(0)
+        self.metrics.stores += 1
+        return IRStore(slot=slot, value=value)
+
+    def _handle_raw(self, event: _Event, stack: List[object]):
+        self.metrics.raw_remaining += 1
+        return None
+
+
+def _pop_args(stack: List[object], count: int) -> List[object]:
+    if count <= 0:
+        return []
+    popped: List[object] = []
+    for _ in range(count):
+        if stack:
+            popped.append(stack.pop())
+        else:
+            popped.append(IRLiteral(0))
+    popped.reverse()
+    return popped
+
+
+def _branch_targets(successors: Sequence[str]) -> Tuple[str, str]:
+    if not successors:
+        return ("fallthrough", "fallthrough")
+    if len(successors) == 1:
+        return (successors[0], "fallthrough")
+    return successors[0], successors[1]
+
+
+def _classify_space(operand: int) -> MemSpace:
+    if operand < 0x1000:
+        return MemSpace.FRAME
+    if operand < 0x8000:
+        return MemSpace.GLOBAL
+    return MemSpace.CONST

--- a/mbcdisasm/ir/pipeline.py
+++ b/mbcdisasm/ir/pipeline.py
@@ -1,0 +1,33 @@
+"""High level entry points for the IR normaliser."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence
+
+from ..instruction import InstructionWord
+from ..knowledge import KnowledgeBase
+from .model import IRProgram, NormalizerMetrics
+from .normalizer import BlockNormaliser
+from .raw import RawSegment, parse_raw_segment
+
+
+def build_segment_ir(
+    instructions: Sequence[InstructionWord], knowledge: KnowledgeBase
+) -> IRProgram:
+    """Normalise a segment worth of instructions into IR blocks."""
+
+    raw = parse_raw_segment(instructions, knowledge)
+    blocks = []
+    metrics = NormalizerMetrics()
+    for block in raw.blocks:
+        normaliser = BlockNormaliser(block)
+        normalised = normaliser.run()
+        metrics.merge(normaliser.metrics)
+        blocks.append(normalised)
+    return IRProgram(blocks=blocks, metrics=metrics)
+
+
+def render_program(program: IRProgram) -> str:
+    """Render ``program`` into a human readable string."""
+
+    return "\n".join(program.render()) + "\n"

--- a/mbcdisasm/ir/raw.py
+++ b/mbcdisasm/ir/raw.py
@@ -1,0 +1,106 @@
+"""Parse instruction words into a raw opcode stream suitable for normalisation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence
+
+from ..instruction import InstructionWord
+from ..knowledge import KnowledgeBase
+from ..analyzer.instruction_profile import InstructionKind, InstructionProfile
+
+
+@dataclass
+class RawInstruction:
+    """Instruction decorated with stack metadata."""
+
+    profile: InstructionProfile
+    stack_delta: int
+    annotations: List[str] = field(default_factory=list)
+
+    @property
+    def mnemonic(self) -> str:
+        return self.profile.mnemonic
+
+    @property
+    def offset(self) -> int:
+        return self.profile.word.offset
+
+
+@dataclass
+class RawBasicBlock:
+    """Simple basic block containing a linear instruction range."""
+
+    label: str
+    instructions: List[RawInstruction] = field(default_factory=list)
+    successors: List[str] = field(default_factory=list)
+
+    def add_instruction(self, instruction: RawInstruction) -> None:
+        self.instructions.append(instruction)
+
+    def add_successor(self, label: str) -> None:
+        if label not in self.successors:
+            self.successors.append(label)
+
+
+@dataclass
+class RawSegment:
+    blocks: Sequence[RawBasicBlock]
+
+
+def parse_raw_segment(
+    words: Sequence[InstructionWord], knowledge: KnowledgeBase
+) -> RawSegment:
+    """Convert instruction ``words`` into :class:`RawBasicBlock` instances."""
+
+    blocks: List[RawBasicBlock] = []
+    current = RawBasicBlock(label=_make_label(len(blocks)))
+    blocks.append(current)
+
+    pending_annotations: List[str] = []
+
+    for idx, word in enumerate(words):
+        profile = InstructionProfile.from_word(word, knowledge)
+        if profile.is_literal_marker():
+            pending_annotations.append(profile.mnemonic)
+            continue
+
+        stack_hint = profile.estimated_stack_delta()
+        instruction = RawInstruction(profile=profile, stack_delta=stack_hint.nominal)
+        if pending_annotations:
+            instruction.annotations.extend(pending_annotations)
+            pending_annotations.clear()
+
+        current.add_instruction(instruction)
+
+        if _terminates_block(profile):
+            successor_label = _make_label(len(blocks))
+            if idx + 1 < len(words):
+                next_block = RawBasicBlock(label=successor_label)
+                blocks.append(next_block)
+                current.add_successor(successor_label)
+                current = next_block
+        elif _starts_new_block(profile):
+            successor_label = _make_label(len(blocks))
+            next_block = RawBasicBlock(label=successor_label)
+            blocks.append(next_block)
+            current.add_successor(successor_label)
+            current = next_block
+
+    return RawSegment(blocks=blocks)
+
+
+def _terminates_block(profile: InstructionProfile) -> bool:
+    if profile.kind in {InstructionKind.RETURN, InstructionKind.TERMINATOR}:
+        return True
+    if profile.mnemonic in {"return_values"}:
+        return True
+    return False
+
+
+def _starts_new_block(profile: InstructionProfile) -> bool:
+    return profile.kind is InstructionKind.BRANCH or profile.mnemonic in {"test_branch", "testset_branch"}
+
+
+def _make_label(index: int) -> str:
+    return f"blk_{index:03d}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,3 +58,8 @@ def test_cli_generates_listing(tmp_path: Path) -> None:
     assert "manual_push" in listing
     assert "Manual override for CLI test." in listing
     assert "disassembly written" in result.stdout
+    ir_path = output_path.with_suffix(".ir.txt")
+    assert ir_path.exists()
+    ir_text = ir_path.read_text("utf-8")
+    assert "metrics:" in ir_text
+    assert "ir written" in result.stdout

--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -1,0 +1,131 @@
+import pytest
+
+from mbcdisasm.ir import (
+    IRBuildMap,
+    IRCall,
+    IRLiteral,
+    IRLoad,
+    IRReturn,
+    IRStore,
+    IRTestSetBranch,
+    MemSpace,
+    build_segment_ir,
+)
+from mbcdisasm.instruction import InstructionWord
+from mbcdisasm.knowledge import KnowledgeBase, OpcodeInfo
+
+
+def _make_word(opcode: int, mode: int, operand: int, offset: int) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | operand
+    return InstructionWord(offset, raw)
+
+
+def _knowledge() -> KnowledgeBase:
+    def mk(
+        mnemonic: str,
+        *,
+        control_flow: str = "fallthrough",
+        stack_delta: int = 0,
+        category: str | None = None,
+    ) -> OpcodeInfo:
+        return OpcodeInfo(
+            mnemonic=mnemonic,
+            summary=None,
+            control_flow=control_flow,
+            category=category,
+            stack_delta=stack_delta,
+        )
+
+    annotations = {
+        "00:00": mk("push_literal", stack_delta=1, category="literal"),
+        "04:00": mk("reduce_pair", stack_delta=-1, category="reduce"),
+        "29:00": mk("tailcall_dispatch", control_flow="call", stack_delta=-1, category="tailcall"),
+        "30:00": mk("return_values", control_flow="return", stack_delta=0, category="return"),
+        "26:00": mk("test_branch", control_flow="branch", stack_delta=-1, category="branch"),
+        "27:00": mk("testset_branch", control_flow="branch", stack_delta=-1, category="branch"),
+        "70:00": mk("indirect_access", stack_delta=1, category="indirect_load"),
+        "70:01": mk("indirect_access", stack_delta=-1, category="indirect_store"),
+    }
+    return KnowledgeBase(annotations)
+
+
+def test_tailcall_sequence_is_collapsed() -> None:
+    knowledge = _knowledge()
+    words = [
+        _make_word(0x00, 0x00, 0x0001, 0),
+        _make_word(0x29, 0x00, 0x1234, 4),
+        _make_word(0x30, 0x00, 0x0000, 8),
+    ]
+    program = build_segment_ir(words, knowledge)
+    block = program.blocks[0]
+    assert len(block.operations) == 2
+    call, ret = block.operations
+    assert isinstance(call, IRCall)
+    assert call.tail is True
+    assert call.args == [IRLiteral(1)]
+    assert isinstance(ret, IRReturn)
+    assert ret.values == []
+
+
+def test_literal_reduce_window_collapses_into_map() -> None:
+    knowledge = _knowledge()
+    words = [
+        _make_word(0x00, 0x00, 0x0001, 0),
+        _make_word(0x00, 0x00, 0x0002, 4),
+        _make_word(0x00, 0x00, 0x0003, 8),
+        _make_word(0x00, 0x00, 0x0004, 12),
+        _make_word(0x04, 0x00, 0x0000, 16),
+        _make_word(0x04, 0x00, 0x0000, 20),
+    ]
+    program = build_segment_ir(words, knowledge)
+    block = program.blocks[0]
+    assert len(block.operations) == 1
+    op = block.operations[0]
+    assert isinstance(op, IRBuildMap)
+    assert len(op.items) == 2
+    assert op.items[0] == (IRLiteral(1), IRLiteral(2))
+    assert op.items[1] == (IRLiteral(3), IRLiteral(4))
+
+
+def test_testset_branch_produces_assigning_predicate() -> None:
+    knowledge = _knowledge()
+    words = [
+        _make_word(0x00, 0x00, 0x0001, 0),
+        _make_word(0x27, 0x00, 0x0000, 4),
+    ]
+    program = build_segment_ir(words, knowledge)
+    block = program.blocks[0]
+    assert any(isinstance(op, IRTestSetBranch) for op in block.operations)
+
+
+def test_indirect_access_classifies_spaces() -> None:
+    knowledge = _knowledge()
+    words = [
+        _make_word(0x70, 0x00, 0x0002, 0),
+        _make_word(0x00, 0x00, 0x0005, 4),
+        _make_word(0x70, 0x01, 0x9000, 8),
+    ]
+    program = build_segment_ir(words, knowledge)
+    block = program.blocks[0]
+    loads = [op for op in block.operations if isinstance(op, IRLoad)]
+    stores = [op for op in block.operations if isinstance(op, IRStore)]
+    assert loads and stores
+    assert loads[0].slot.space is MemSpace.FRAME
+    assert stores[0].slot.space is MemSpace.CONST
+
+
+def test_metrics_report_counts() -> None:
+    knowledge = _knowledge()
+    words = [
+        _make_word(0x00, 0x00, 0x0001, 0),
+        _make_word(0x29, 0x00, 0x1234, 4),
+        _make_word(0x30, 0x00, 0x0000, 8),
+        _make_word(0x70, 0x00, 0x0004, 12),
+    ]
+    program = build_segment_ir(words, knowledge)
+    metrics = program.metrics
+    assert metrics.calls == 1
+    assert metrics.tail_calls == 1
+    assert metrics.returns == 1
+    assert metrics.loads == 1
+    assert metrics.raw_remaining == 0


### PR DESCRIPTION
## Summary
- add a dedicated IR package with dataclasses, raw parsing, and a multi-pass normaliser
- integrate IR generation into the disassembler CLI and emit per-segment IR dumps
- cover the new behaviour with focused unit tests and extend the CLI smoke test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e03a2f448c832fbe472d59239853d2