### PR TITLE
Add IR normalizer pipeline and integrate IR output into CLI

### DIFF
--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -3,6 +3,7 @@
 from .adb import SegmentDescriptor, SegmentIndex
 from .disassembler import Disassembler
 from .instruction import InstructionWord
+from .ir import IRNormalizer, IRTextRenderer
 from .knowledge import KnowledgeBase
 from .mbc import MbcContainer, Segment
 
@@ -14,4 +15,6 @@ __all__ = [
     "KnowledgeBase",
     "MbcContainer",
     "Segment",
+    "IRNormalizer",
+    "IRTextRenderer",
 ]

--- a/mbcdisasm/ir/__init__.py
+++ b/mbcdisasm/ir/__init__.py
@@ -1,0 +1,44 @@
+"""Public exports for the IR normalisation pipeline."""
+
+from .model import (
+    IRBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRLoad,
+    IRNode,
+    IRProgram,
+    IRRaw,
+    IRReturn,
+    IRSegment,
+    IRSlot,
+    IRStore,
+    IRTestSetBranch,
+    IRIf,
+    MemSpace,
+    NormalizerMetrics,
+)
+from .normalizer import IRNormalizer
+from .printer import IRTextRenderer
+
+__all__ = [
+    "IRNormalizer",
+    "IRTextRenderer",
+    "IRProgram",
+    "IRSegment",
+    "IRBlock",
+    "IRCall",
+    "IRReturn",
+    "IRBuildArray",
+    "IRBuildMap",
+    "IRBuildTuple",
+    "IRIf",
+    "IRTestSetBranch",
+    "IRLoad",
+    "IRStore",
+    "IRSlot",
+    "IRRaw",
+    "MemSpace",
+    "NormalizerMetrics",
+]

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -1,0 +1,254 @@
+"""Dataclasses describing the normalised intermediate representation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Tuple
+
+
+class MemSpace(Enum):
+    """High level classification of indirect memory accesses."""
+
+    FRAME = auto()
+    GLOBAL = auto()
+    CONST = auto()
+
+
+@dataclass(frozen=True)
+class IRSlot:
+    """Address of a VM slot used by :class:`IRLoad` and :class:`IRStore`."""
+
+    space: MemSpace
+    index: int
+
+
+@dataclass(frozen=True)
+class IRNode:
+    """Base class for IR nodes.
+
+    The class only exists to make type signatures more explicit.  Subclasses do
+    not rely on runtime inheritance checks so the dataclasses can remain frozen
+    which keeps the structures hashable and easy to compare in tests.
+    """
+
+
+@dataclass(frozen=True)
+class IRCall(IRNode):
+    """Invocation of another routine."""
+
+    target: int
+    args: Tuple[str, ...]
+    tail: bool = False
+
+    def describe(self) -> str:
+        suffix = " tail" if self.tail else ""
+        args = ", ".join(self.args)
+        return f"call{suffix} target=0x{self.target:04X} args=[{args}]"
+
+
+@dataclass(frozen=True)
+class IRReturn(IRNode):
+    """Return from the current routine."""
+
+    values: Tuple[str, ...]
+
+    def describe(self) -> str:
+        values = ", ".join(self.values)
+        return f"return [{values}]"
+
+
+@dataclass(frozen=True)
+class IRBuildArray(IRNode):
+    """Aggregate literal values into a positional container."""
+
+    elements: Tuple[str, ...]
+
+    def describe(self) -> str:
+        values = ", ".join(self.elements)
+        return f"array([{values}])"
+
+
+@dataclass(frozen=True)
+class IRBuildMap(IRNode):
+    """Aggregate literal values into a key/value container."""
+
+    entries: Tuple[Tuple[str, str], ...]
+
+    def describe(self) -> str:
+        pairs = ", ".join(f"{key}:{value}" for key, value in self.entries)
+        return f"map([{pairs}])"
+
+
+@dataclass(frozen=True)
+class IRBuildTuple(IRNode):
+    """Aggregate literal values into an immutable tuple."""
+
+    elements: Tuple[str, ...]
+
+    def describe(self) -> str:
+        values = ", ".join(self.elements)
+        return f"tuple([{values}])"
+
+
+@dataclass(frozen=True)
+class IRIf(IRNode):
+    """Standard conditional branch."""
+
+    condition: str
+    then_target: int
+    else_target: int
+
+    def describe(self) -> str:
+        return (
+            f"if cond={self.condition} then=0x{self.then_target:04X} "
+            f"else=0x{self.else_target:04X}"
+        )
+
+
+@dataclass(frozen=True)
+class IRTestSetBranch(IRNode):
+    """Branch that stores the predicate before testing it."""
+
+    var: str
+    expr: str
+    then_target: int
+    else_target: int
+
+    def describe(self) -> str:
+        return (
+            f"testset {self.var}={self.expr} then=0x{self.then_target:04X} "
+            f"else=0x{self.else_target:04X}"
+        )
+
+
+@dataclass(frozen=True)
+class IRLoad(IRNode):
+    """Load a value from a VM slot."""
+
+    slot: IRSlot
+    target: str = "stack"
+
+    def describe(self) -> str:
+        return f"load {self.slot.space.name.lower()}[{self.slot.index}] -> {self.target}"
+
+
+@dataclass(frozen=True)
+class IRStore(IRNode):
+    """Store a value into a VM slot."""
+
+    slot: IRSlot
+    value: str = "stack"
+
+    def describe(self) -> str:
+        return f"store {self.value} -> {self.slot.space.name.lower()}[{self.slot.index}]"
+
+
+@dataclass(frozen=True)
+class IRRaw(IRNode):
+    """Fallback wrapper for instructions that have not been normalised."""
+
+    mnemonic: str
+    operand: int
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
+
+    def describe(self) -> str:
+        note = ""
+        if self.annotations:
+            note = " " + ", ".join(self.annotations)
+        return f"raw {self.mnemonic} operand=0x{self.operand:04X}{note}"
+
+
+@dataclass(frozen=True)
+class IRBlock:
+    """Single basic block in the IR programme."""
+
+    label: str
+    start_offset: int
+    nodes: Tuple[IRNode, ...]
+
+
+@dataclass(frozen=True)
+class IRSegment:
+    """Collection of IR blocks corresponding to a container segment."""
+
+    index: int
+    start: int
+    length: int
+    blocks: Tuple[IRBlock, ...]
+    metrics: "NormalizerMetrics"
+
+
+@dataclass(frozen=True)
+class IRProgram:
+    """Normalised representation for the entire container."""
+
+    segments: Tuple[IRSegment, ...]
+    metrics: "NormalizerMetrics"
+
+
+@dataclass
+class NormalizerMetrics:
+    """Aggregate counts recorded during normalisation."""
+
+    calls: int = 0
+    tail_calls: int = 0
+    returns: int = 0
+    aggregates: int = 0
+    testset_branches: int = 0
+    if_branches: int = 0
+    loads: int = 0
+    stores: int = 0
+    reduce_replaced: int = 0
+    raw_remaining: int = 0
+
+    def observe(self, other: "NormalizerMetrics") -> None:
+        """Accumulate values from ``other`` into this instance."""
+
+        self.calls += other.calls
+        self.tail_calls += other.tail_calls
+        self.returns += other.returns
+        self.aggregates += other.aggregates
+        self.testset_branches += other.testset_branches
+        self.if_branches += other.if_branches
+        self.loads += other.loads
+        self.stores += other.stores
+        self.reduce_replaced += other.reduce_replaced
+        self.raw_remaining += other.raw_remaining
+
+    def describe(self) -> str:
+        """Return a stable textual summary of the metrics."""
+
+        parts = [
+            f"calls={self.calls}",
+            f"tail_calls={self.tail_calls}",
+            f"returns={self.returns}",
+            f"aggregates={self.aggregates}",
+            f"testset_branches={self.testset_branches}",
+            f"if_branches={self.if_branches}",
+            f"loads={self.loads}",
+            f"stores={self.stores}",
+            f"reduce_replaced={self.reduce_replaced}",
+            f"raw_remaining={self.raw_remaining}",
+        ]
+        return " ".join(parts)
+
+
+__all__ = [
+    "IRProgram",
+    "IRSegment",
+    "IRBlock",
+    "IRCall",
+    "IRReturn",
+    "IRBuildArray",
+    "IRBuildMap",
+    "IRBuildTuple",
+    "IRIf",
+    "IRTestSetBranch",
+    "IRLoad",
+    "IRStore",
+    "IRSlot",
+    "IRRaw",
+    "MemSpace",
+    "NormalizerMetrics",
+]

--- a/mbcdisasm/ir/normalizer.py
+++ b/mbcdisasm/ir/normalizer.py
@@ -1,0 +1,471 @@
+"""Normalisation pipeline that converts raw instructions into IR nodes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union
+
+from ..analyzer.instruction_profile import InstructionKind, InstructionProfile
+from ..analyzer.stack import StackEvent, StackTracker
+from ..instruction import read_instructions
+from ..knowledge import KnowledgeBase
+from ..mbc import MbcContainer, Segment
+from .model import (
+    IRBlock,
+    IRBuildArray,
+    IRBuildMap,
+    IRBuildTuple,
+    IRCall,
+    IRLoad,
+    IRNode,
+    IRProgram,
+    IRRaw,
+    IRReturn,
+    IRSegment,
+    IRSlot,
+    IRStore,
+    IRTestSetBranch,
+    IRIf,
+    MemSpace,
+    NormalizerMetrics,
+)
+
+
+ANNOTATION_MNEMONICS = {"literal_marker", "inline_ascii_chunk"}
+
+
+@dataclass(frozen=True)
+class RawInstruction:
+    """Wrapper that couples a profile with stack tracking details."""
+
+    profile: InstructionProfile
+    event: StackEvent
+    annotations: Tuple[str, ...]
+
+    @property
+    def mnemonic(self) -> str:
+        return self.profile.mnemonic
+
+    @property
+    def operand(self) -> int:
+        return self.profile.word.operand
+
+    @property
+    def offset(self) -> int:
+        return self.profile.word.offset
+
+    def pushes_value(self) -> bool:
+        return bool(self.event.pushed_types)
+
+    def describe_source(self) -> str:
+        return f"{self.profile.label}@0x{self.offset:06X}"
+
+
+@dataclass(frozen=True)
+class RawBlock:
+    """Sequence of executable instructions terminated by control flow."""
+
+    index: int
+    start_offset: int
+    instructions: Tuple[RawInstruction, ...]
+
+
+class _ItemList:
+    """Mutable wrapper around a block during normalisation passes."""
+
+    def __init__(self, items: Sequence[Union[RawInstruction, IRNode]]):
+        self._items: List[Union[RawInstruction, IRNode]] = list(items)
+
+    def __iter__(self) -> Iterator[Union[RawInstruction, IRNode]]:
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, index: int) -> Union[RawInstruction, IRNode]:
+        return self._items[index]
+
+    def replace_slice(
+        self, start: int, end: int, replacement: Sequence[Union[RawInstruction, IRNode]]
+    ) -> None:
+        self._items[start:end] = list(replacement)
+
+    def insert(self, index: int, value: Union[RawInstruction, IRNode]) -> None:
+        self._items.insert(index, value)
+
+    def pop(self, index: int) -> Union[RawInstruction, IRNode]:
+        return self._items.pop(index)
+
+    def to_tuple(self) -> Tuple[Union[RawInstruction, IRNode], ...]:
+        return tuple(self._items)
+
+
+class IRNormalizer:
+    """Drive the multi-pass IR normalisation pipeline."""
+
+    def __init__(self, knowledge: KnowledgeBase) -> None:
+        self.knowledge = knowledge
+
+    # ------------------------------------------------------------------
+    # public entry points
+    # ------------------------------------------------------------------
+    def normalise_container(
+        self,
+        container: MbcContainer,
+        *,
+        segment_indices: Optional[Sequence[int]] = None,
+    ) -> IRProgram:
+        segments: List[IRSegment] = []
+        aggregate_metrics = NormalizerMetrics()
+        selection = set(segment_indices or [])
+
+        for segment in container.segments():
+            if selection and segment.index not in selection:
+                continue
+            normalised = self.normalise_segment(segment)
+            segments.append(normalised)
+            aggregate_metrics.observe(normalised.metrics)
+
+        return IRProgram(segments=tuple(segments), metrics=aggregate_metrics)
+
+    def normalise_segment(self, segment: Segment) -> IRSegment:
+        raw_blocks = self._parse_segment(segment)
+        blocks: List[IRBlock] = []
+        metrics = NormalizerMetrics()
+
+        for block in raw_blocks:
+            ir_block, block_metrics = self._normalise_block(block)
+            blocks.append(ir_block)
+            metrics.observe(block_metrics)
+
+        return IRSegment(
+            index=segment.index,
+            start=segment.start,
+            length=segment.length,
+            blocks=tuple(blocks),
+            metrics=metrics,
+        )
+
+    # ------------------------------------------------------------------
+    # parsing helpers
+    # ------------------------------------------------------------------
+    def _parse_segment(self, segment: Segment) -> Tuple[RawBlock, ...]:
+        instructions, _ = read_instructions(segment.data, segment.start)
+        if not instructions:
+            return tuple()
+
+        profiles = [InstructionProfile.from_word(word, self.knowledge) for word in instructions]
+        executable: List[InstructionProfile] = []
+        annotations: Dict[int, List[str]] = {}
+        pending: List[str] = []
+
+        for profile in profiles:
+            if profile.mnemonic in ANNOTATION_MNEMONICS or (
+                profile.is_literal_marker() and profile.mnemonic.startswith("op_")
+            ):
+                pending.append(profile.mnemonic)
+                continue
+            index = len(executable)
+            if pending:
+                annotations.setdefault(index, []).extend(pending)
+                pending.clear()
+            executable.append(profile)
+
+        tracker = StackTracker()
+        events = tracker.process_sequence(executable)
+
+        raw_instructions: List[RawInstruction] = []
+        for index, (profile, event) in enumerate(zip(executable, events)):
+            notes = tuple(annotations.get(index, ()))
+            raw_instructions.append(RawInstruction(profile=profile, event=event, annotations=notes))
+
+        blocks: List[RawBlock] = []
+        current: List[RawInstruction] = []
+        block_index = 0
+        block_start = raw_instructions[0].offset if raw_instructions else segment.start
+
+        for instruction in raw_instructions:
+            if not current:
+                block_start = instruction.offset
+            current.append(instruction)
+            if self._is_block_terminator(instruction):
+                blocks.append(
+                    RawBlock(index=block_index, start_offset=block_start, instructions=tuple(current))
+                )
+                block_index += 1
+                current = []
+
+        if current:
+            blocks.append(
+                RawBlock(index=block_index, start_offset=block_start, instructions=tuple(current))
+            )
+
+        return tuple(blocks)
+
+    @staticmethod
+    def _is_block_terminator(instruction: RawInstruction) -> bool:
+        profile = instruction.profile
+        if profile.kind in {
+            InstructionKind.BRANCH,
+            InstructionKind.RETURN,
+            InstructionKind.TERMINATOR,
+            InstructionKind.TAILCALL,
+        }:
+            return True
+        control = (profile.control_flow or "").lower()
+        return any(token in control for token in {"return", "jump", "stop"})
+
+    # ------------------------------------------------------------------
+    # normalisation passes
+    # ------------------------------------------------------------------
+    def _normalise_block(self, block: RawBlock) -> Tuple[IRBlock, NormalizerMetrics]:
+        items = _ItemList(block.instructions)
+        metrics = NormalizerMetrics()
+
+        self._pass_calls_and_returns(items, metrics)
+        self._pass_aggregates(items, metrics)
+        self._pass_branches(items, metrics)
+        self._pass_indirect_access(items, metrics)
+
+        nodes: List[IRNode] = []
+        for item in items:
+            if isinstance(item, RawInstruction):
+                metrics.raw_remaining += 1
+                nodes.append(
+                    IRRaw(
+                        mnemonic=item.mnemonic,
+                        operand=item.operand,
+                        annotations=item.annotations,
+                    )
+                )
+            else:
+                nodes.append(item)
+
+        ir_block = IRBlock(label=f"block_{block.index}", start_offset=block.start_offset, nodes=tuple(nodes))
+        return ir_block, metrics
+
+    # ------------------------------------------------------------------
+    # individual pass implementations
+    # ------------------------------------------------------------------
+    def _pass_calls_and_returns(self, items: _ItemList, metrics: NormalizerMetrics) -> None:
+        index = 0
+        while index < len(items):
+            item = items[index]
+            if not isinstance(item, RawInstruction):
+                index += 1
+                continue
+
+            mnemonic = item.mnemonic
+            if mnemonic in {"call_dispatch", "tailcall_dispatch"}:
+                args, start = self._collect_call_arguments(items, index)
+                call = IRCall(target=item.operand, args=tuple(args), tail=mnemonic == "tailcall_dispatch")
+                metrics.calls += 1
+                if call.tail:
+                    metrics.tail_calls += 1
+                items.replace_slice(start, index + 1, [call])
+                index = start
+                if call.tail:
+                    self._collapse_tail_return(items, index, metrics)
+                continue
+
+            if mnemonic == "return_values":
+                arity = self._return_arity(item)
+                values = tuple(f"ret{i}" for i in range(arity))
+                items.replace_slice(index, index + 1, [IRReturn(values=values)])
+                metrics.returns += 1
+                continue
+
+            index += 1
+
+    def _collect_call_arguments(
+        self, items: _ItemList, call_index: int
+    ) -> Tuple[List[str], int]:
+        args: List[str] = []
+        start = call_index
+        scan = call_index - 1
+        while scan >= 0:
+            candidate = items[scan]
+            if not isinstance(candidate, RawInstruction):
+                break
+            if candidate.pushes_value():
+                args.append(self._describe_value(candidate))
+                scan -= 1
+                continue
+            break
+        args.reverse()
+        start = scan + 1
+        return args, start
+
+    def _collapse_tail_return(self, items: _ItemList, call_index: int, metrics: NormalizerMetrics) -> None:
+        index = call_index + 1
+        while index < len(items):
+            item = items[index]
+            if isinstance(item, RawInstruction) and item.mnemonic == "return_values":
+                arity = self._return_arity(item)
+                values = tuple(f"ret{i}" for i in range(arity))
+                items.replace_slice(index, index + 1, [IRReturn(values=values)])
+                metrics.returns += 1
+                return
+            if isinstance(item, RawInstruction) and item.profile.kind in {
+                InstructionKind.STACK_TEARDOWN,
+                InstructionKind.META,
+            }:
+                items.pop(index)
+                continue
+            break
+
+    def _return_arity(self, instruction: RawInstruction) -> int:
+        operand = instruction.operand
+        lo = operand & 0xFF
+        hi = (operand >> 8) & 0xFF
+        if lo:
+            return lo
+        if hi:
+            return hi
+        return 1
+
+    def _pass_aggregates(self, items: _ItemList, metrics: NormalizerMetrics) -> None:
+        index = 0
+        while index < len(items):
+            item = items[index]
+            if not isinstance(item, RawInstruction) or item.mnemonic != "push_literal":
+                index += 1
+                continue
+
+            literal_instructions: List[RawInstruction] = []
+            reducers: List[RawInstruction] = []
+            scan = index
+            while scan < len(items):
+                candidate = items[scan]
+                if isinstance(candidate, RawInstruction) and candidate.mnemonic == "push_literal":
+                    literal_instructions.append(candidate)
+                    scan += 1
+                    continue
+                if isinstance(candidate, RawInstruction) and candidate.mnemonic.startswith("reduce"):
+                    reducers.append(candidate)
+                    scan += 1
+                    continue
+                break
+
+            if not reducers:
+                index += 1
+                continue
+
+            literals = [self._describe_value(instr) for instr in literal_instructions]
+            replacement: IRNode
+            if len(literals) >= 2 and len(literals) == 2 * len(reducers):
+                entries = []
+                for pos in range(0, len(literals), 2):
+                    entries.append((literals[pos], literals[pos + 1]))
+                replacement = IRBuildMap(entries=tuple(entries))
+            elif len(literals) == len(reducers) + 1:
+                replacement = IRBuildArray(elements=tuple(literals))
+            else:
+                replacement = IRBuildTuple(elements=tuple(literals))
+
+            metrics.aggregates += 1
+            metrics.reduce_replaced += len(reducers)
+            items.replace_slice(index, scan, [replacement])
+            index += 1
+
+    def _pass_branches(self, items: _ItemList, metrics: NormalizerMetrics) -> None:
+        index = 0
+        while index < len(items):
+            item = items[index]
+            if not isinstance(item, RawInstruction):
+                index += 1
+                continue
+
+            if item.mnemonic == "testset_branch":
+                expr = self._describe_condition(items, index)
+                node = IRTestSetBranch(
+                    var=f"t{index}",
+                    expr=expr,
+                    then_target=self._branch_target(item),
+                    else_target=self._fallthrough_target(item),
+                )
+                items.replace_slice(index, index + 1, [node])
+                metrics.testset_branches += 1
+                continue
+
+            if item.profile.kind is InstructionKind.BRANCH:
+                node = IRIf(
+                    condition=self._describe_condition(items, index),
+                    then_target=self._branch_target(item),
+                    else_target=self._fallthrough_target(item),
+                )
+                items.replace_slice(index, index + 1, [node])
+                metrics.if_branches += 1
+                continue
+
+            index += 1
+
+    def _pass_indirect_access(self, items: _ItemList, metrics: NormalizerMetrics) -> None:
+        index = 0
+        while index < len(items):
+            item = items[index]
+            if not isinstance(item, RawInstruction):
+                index += 1
+                continue
+
+            kind = item.event.kind
+            if kind in {InstructionKind.INDIRECT_LOAD, InstructionKind.INDIRECT}:
+                slot = self._classify_slot(item.operand)
+                node = IRLoad(slot=slot)
+                items.replace_slice(index, index + 1, [node])
+                metrics.loads += 1
+                continue
+            if kind is InstructionKind.INDIRECT_STORE:
+                slot = self._classify_slot(item.operand)
+                node = IRStore(slot=slot)
+                items.replace_slice(index, index + 1, [node])
+                metrics.stores += 1
+                continue
+
+            index += 1
+
+    # ------------------------------------------------------------------
+    # description helpers
+    # ------------------------------------------------------------------
+    def _describe_value(self, instruction: RawInstruction) -> str:
+        mnemonic = instruction.mnemonic
+        operand = instruction.operand
+        if mnemonic == "push_literal":
+            return f"lit(0x{operand:04X})"
+        if mnemonic.startswith("reduce"):
+            return f"reduce(0x{operand:04X})"
+        if "slot" in mnemonic:
+            return f"slot(0x{operand:04X})"
+        return instruction.describe_source()
+
+    def _describe_condition(self, items: _ItemList, index: int) -> str:
+        scan = index - 1
+        while scan >= 0:
+            candidate = items[scan]
+            if isinstance(candidate, RawInstruction) and candidate.pushes_value():
+                return self._describe_value(candidate)
+            if isinstance(candidate, IRNode):
+                return getattr(candidate, "describe", lambda: "expr()")()
+            scan -= 1
+        return "stack_top"
+
+    @staticmethod
+    def _branch_target(instruction: RawInstruction) -> int:
+        return instruction.operand
+
+    @staticmethod
+    def _fallthrough_target(instruction: RawInstruction) -> int:
+        return instruction.offset + 4
+
+    @staticmethod
+    def _classify_slot(operand: int) -> IRSlot:
+        if operand < 0x1000:
+            space = MemSpace.FRAME
+        elif operand < 0x8000:
+            space = MemSpace.GLOBAL
+        else:
+            space = MemSpace.CONST
+        return IRSlot(space=space, index=operand)
+
+
+__all__ = ["IRNormalizer", "RawInstruction", "RawBlock"]

--- a/mbcdisasm/ir/printer.py
+++ b/mbcdisasm/ir/printer.py
@@ -1,0 +1,48 @@
+"""Utilities for serialising the normalised IR into a text format."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+from .model import IRBlock, IRProgram, IRSegment
+
+
+class IRTextRenderer:
+    """Render :class:`IRProgram` instances into a stable textual form."""
+
+    def render(self, program: IRProgram) -> str:
+        lines: List[str] = []
+        lines.append("; normalizer metrics: " + program.metrics.describe())
+        for segment in program.segments:
+            lines.extend(self._render_segment(segment))
+        return "\n".join(lines) + "\n"
+
+    def write(self, program: IRProgram, output_path: Path) -> None:
+        output_path.write_text(self.render(program), "utf-8")
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _render_segment(self, segment: IRSegment) -> Iterable[str]:
+        header = (
+            f"; segment {segment.index} offset=0x{segment.start:06X} "
+            f"length={segment.length}"
+        )
+        yield header
+        yield "; metrics: " + segment.metrics.describe()
+        for block in segment.blocks:
+            yield from self._render_block(block)
+        yield ""
+
+    def _render_block(self, block: IRBlock) -> Iterable[str]:
+        yield f"block {block.label} offset=0x{block.start_offset:06X}"
+        for node in block.nodes:
+            describe = getattr(node, "describe", None)
+            if callable(describe):
+                yield f"  {describe()}"
+            else:
+                yield f"  {node!r}"
+
+
+__all__ = ["IRTextRenderer"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,3 +58,8 @@ def test_cli_generates_listing(tmp_path: Path) -> None:
     assert "manual_push" in listing
     assert "Manual override for CLI test." in listing
     assert "disassembly written" in result.stdout
+    ir_output = mbc_path.with_suffix(".ir.txt")
+    assert ir_output.exists()
+    ir_text = ir_output.read_text("utf-8")
+    assert "normalizer metrics" in ir_text
+    assert "segment" in ir_text

--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -1,0 +1,136 @@
+import json
+from pathlib import Path
+
+from mbcdisasm import IRNormalizer, KnowledgeBase, MbcContainer
+from mbcdisasm.adb import SegmentDescriptor
+from mbcdisasm.ir import IRTextRenderer
+from mbcdisasm.mbc import Segment
+from mbcdisasm.instruction import InstructionWord
+
+
+def build_word(offset: int, opcode: int, mode: int, operand: int) -> InstructionWord:
+    raw = (opcode << 24) | (mode << 16) | (operand & 0xFFFF)
+    return InstructionWord(offset=offset, raw=raw)
+
+
+def encode_instructions(words: list[InstructionWord]) -> bytes:
+    return b"".join(word.raw.to_bytes(4, "big") for word in words)
+
+
+def write_manual(path: Path) -> KnowledgeBase:
+    manual = {
+        "push_literal": {
+            "opcodes": ["00:00"],
+            "name": "push_literal",
+            "category": "literal",
+            "stack_push": 1,
+        },
+        "reduce_pair": {
+            "opcodes": ["04:00"],
+            "name": "reduce_pair",
+            "category": "reduce",
+            "stack_delta": -1,
+        },
+        "tailcall_dispatch": {
+            "opcodes": ["0x29:0x00"],
+            "name": "tailcall_dispatch",
+            "category": "tailcall_dispatch",
+        },
+        "return_values": {
+            "opcodes": ["0x30:0x00"],
+            "name": "return_values",
+            "category": "return_values",
+        },
+        "branch_eq": {
+            "opcodes": ["0x23:0x00"],
+            "name": "branch_eq",
+            "category": "branch_eq",
+        },
+        "testset_branch": {
+            "opcodes": ["0x27:0x00"],
+            "name": "testset_branch",
+            "category": "testset_branch",
+        },
+        "indirect_access": {
+            "opcodes": ["0x69:0x01"],
+            "name": "indirect_access",
+            "category": "indirect_access",
+        },
+        "stack_teardown_1": {
+            "opcodes": ["0x01:0x00"],
+            "name": "stack_teardown_1",
+            "category": "stack_teardown",
+        },
+    }
+    manual_path = path / "manual_annotations.json"
+    manual_path.write_text(json.dumps(manual, indent=2), "utf-8")
+    return KnowledgeBase.load(manual_path)
+
+
+def build_container(tmp_path: Path) -> tuple[MbcContainer, KnowledgeBase]:
+    knowledge = write_manual(tmp_path)
+
+    seg0_words = [
+        build_word(0, 0x00, 0x00, 0x0001),
+        build_word(4, 0x00, 0x00, 0x0002),
+        build_word(8, 0x29, 0x00, 0x1234),
+        build_word(12, 0x30, 0x00, 0x0002),
+    ]
+    seg1_words = [
+        build_word(0, 0x00, 0x00, 0x0003),
+        build_word(4, 0x00, 0x00, 0x0004),
+        build_word(8, 0x04, 0x00, 0x0000),
+        build_word(12, 0x23, 0x00, 0x0010),
+        build_word(16, 0x00, 0x00, 0x0005),
+        build_word(20, 0x27, 0x00, 0x0008),
+        build_word(24, 0x69, 0x01, 0x0005),
+        build_word(28, 0x69, 0x01, 0x9000),
+        build_word(32, 0x01, 0x00, 0x0000),
+    ]
+
+    seg0_bytes = encode_instructions(seg0_words)
+    seg1_bytes = encode_instructions(seg1_words)
+
+    segments = [
+        Segment(SegmentDescriptor(0, 0, len(seg0_bytes)), seg0_bytes),
+        Segment(
+            SegmentDescriptor(1, len(seg0_bytes), len(seg0_bytes) + len(seg1_bytes)),
+            seg1_bytes,
+        ),
+    ]
+
+    container = MbcContainer(Path("dummy"), segments)
+    return container, knowledge
+
+
+def test_normalizer_builds_ir(tmp_path: Path) -> None:
+    container, knowledge = build_container(tmp_path)
+    normalizer = IRNormalizer(knowledge)
+    program = normalizer.normalise_container(container)
+
+    assert program.metrics.calls == 1
+    assert program.metrics.tail_calls == 1
+    assert program.metrics.returns >= 1
+    assert program.metrics.aggregates == 1
+    assert program.metrics.testset_branches == 1
+    assert program.metrics.if_branches == 1
+    assert program.metrics.loads == 1
+    assert program.metrics.stores == 1
+    assert program.metrics.reduce_replaced == 1
+
+    segment = program.segments[1]
+    descriptions = [
+        getattr(node, "describe", lambda: "")()
+        for block in segment.blocks
+        for node in block.nodes
+    ]
+    assert any("map" in text for text in descriptions)
+    assert any(text.startswith("if cond") for text in descriptions)
+    assert any(text.startswith("testset") for text in descriptions)
+    assert any(text.startswith("load") for text in descriptions)
+    assert any(text.startswith("store") for text in descriptions)
+
+    renderer = IRTextRenderer()
+    text = renderer.render(program)
+    assert "normalizer metrics" in text
+    assert f"segment {segment.index}" in text


### PR DESCRIPTION
## Summary
- add a dedicated IR package with dataclasses, normalisation passes, and a text renderer
- export the IR toolkit and wire the CLI to emit a normalised `.ir.txt` alongside the disassembly
- cover the pipeline with new unit tests and extend the CLI regression test to validate the IR output

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e03a2f448c832fbe472d59239853d2