### PR TITLE
Improve IR normalization for annotations and control flow

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -166,6 +166,7 @@ class IRBlock:
     label: str
     start_offset: int
     nodes: Tuple[IRNode, ...]
+    annotations: Tuple[Tuple[int, Tuple[str, ...]], ...] = tuple()
 
 
 @dataclass(frozen=True)

--- a/mbcdisasm/ir/normalizer.py
+++ b/mbcdisasm/ir/normalizer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 from ..analyzer.instruction_profile import InstructionKind, InstructionProfile
@@ -41,6 +41,8 @@ class RawInstruction:
     profile: InstructionProfile
     event: StackEvent
     annotations: Tuple[str, ...]
+    annotation_offsets: Tuple[int, ...] = tuple()
+    metadata_only: bool = False
 
     @property
     def mnemonic(self) -> str:
@@ -68,6 +70,7 @@ class RawBlock:
     index: int
     start_offset: int
     instructions: Tuple[RawInstruction, ...]
+    annotations: Tuple[Tuple[int, Tuple[str, ...]], ...]
 
 
 class _ItemList:
@@ -157,30 +160,49 @@ class IRNormalizer:
         profiles = [InstructionProfile.from_word(word, self.knowledge) for word in instructions]
         executable: List[InstructionProfile] = []
         annotations: Dict[int, List[str]] = {}
-        pending: List[str] = []
+        annotation_offsets: Dict[int, List[int]] = {}
+        pending_labels: List[str] = []
+        pending_offsets: List[int] = []
+        trailing_annotations: List[Tuple[int, str]] = []
 
         for profile in profiles:
             if profile.mnemonic in ANNOTATION_MNEMONICS or (
-                profile.is_literal_marker() and profile.mnemonic.startswith("op_")
+                profile.is_literal_marker()
+                and (profile.mnemonic.startswith("op_") or profile.mnemonic == "literal_marker")
             ):
-                pending.append(profile.mnemonic)
+                pending_labels.append(self._annotation_label(profile))
+                pending_offsets.append(profile.word.offset)
                 continue
             index = len(executable)
-            if pending:
-                annotations.setdefault(index, []).extend(pending)
-                pending.clear()
+            if pending_labels:
+                annotations.setdefault(index, []).extend(pending_labels)
+                annotation_offsets.setdefault(index, []).extend(pending_offsets)
+                pending_labels.clear()
+                pending_offsets.clear()
             executable.append(profile)
+
+        if pending_labels:
+            trailing_annotations.extend(zip(pending_offsets, pending_labels))
 
         tracker = StackTracker()
         events = tracker.process_sequence(executable)
 
         raw_instructions: List[RawInstruction] = []
         for index, (profile, event) in enumerate(zip(executable, events)):
-            notes = tuple(annotations.get(index, ()))
-            raw_instructions.append(RawInstruction(profile=profile, event=event, annotations=notes))
+            labels = annotations.get(index, ())
+            offsets = annotation_offsets.get(index, ())
+            raw_instructions.append(
+                RawInstruction(
+                    profile=profile,
+                    event=event,
+                    annotations=tuple(labels),
+                    annotation_offsets=tuple(offsets),
+                )
+            )
 
         blocks: List[RawBlock] = []
         current: List[RawInstruction] = []
+        current_annotations: List[Tuple[int, Tuple[str, ...]]] = []
         block_index = 0
         block_start = raw_instructions[0].offset if raw_instructions else segment.start
 
@@ -188,16 +210,35 @@ class IRNormalizer:
             if not current:
                 block_start = instruction.offset
             current.append(instruction)
+            if instruction.annotation_offsets:
+                grouped = [
+                    (offset, (label,))
+                    for offset, label in zip(instruction.annotation_offsets, instruction.annotations)
+                ]
+                current_annotations.extend(grouped)
             if self._is_block_terminator(instruction):
                 blocks.append(
-                    RawBlock(index=block_index, start_offset=block_start, instructions=tuple(current))
+                    RawBlock(
+                        index=block_index,
+                        start_offset=block_start,
+                        instructions=tuple(current),
+                        annotations=tuple(current_annotations),
+                    )
                 )
                 block_index += 1
                 current = []
+                current_annotations = []
 
         if current:
+            if trailing_annotations:
+                current_annotations.extend((offset, (label,)) for offset, label in trailing_annotations)
             blocks.append(
-                RawBlock(index=block_index, start_offset=block_start, instructions=tuple(current))
+                RawBlock(
+                    index=block_index,
+                    start_offset=block_start,
+                    instructions=tuple(current),
+                    annotations=tuple(current_annotations),
+                )
             )
 
         return tuple(blocks)
@@ -215,12 +256,21 @@ class IRNormalizer:
         control = (profile.control_flow or "").lower()
         return any(token in control for token in {"return", "jump", "stop"})
 
+    @staticmethod
+    def _annotation_label(profile: InstructionProfile) -> str:
+        if profile.mnemonic in ANNOTATION_MNEMONICS:
+            return profile.mnemonic
+        if profile.is_literal_marker():
+            return "literal_marker"
+        return profile.mnemonic
+
     # ------------------------------------------------------------------
     # normalisation passes
     # ------------------------------------------------------------------
     def _normalise_block(self, block: RawBlock) -> Tuple[IRBlock, NormalizerMetrics]:
         items = _ItemList(block.instructions)
         metrics = NormalizerMetrics()
+        annotations: List[Tuple[int, Tuple[str, ...]]] = list(block.annotations)
 
         self._pass_calls_and_returns(items, metrics)
         self._pass_aggregates(items, metrics)
@@ -230,6 +280,9 @@ class IRNormalizer:
         nodes: List[IRNode] = []
         for item in items:
             if isinstance(item, RawInstruction):
+                if self._is_metadata_instruction(item):
+                    annotations.append(self._metadata_entry(item))
+                    continue
                 metrics.raw_remaining += 1
                 nodes.append(
                     IRRaw(
@@ -241,7 +294,12 @@ class IRNormalizer:
             else:
                 nodes.append(item)
 
-        ir_block = IRBlock(label=f"block_{block.index}", start_offset=block.start_offset, nodes=tuple(nodes))
+        ir_block = IRBlock(
+            label=f"block_{block.index}",
+            start_offset=block.start_offset,
+            nodes=tuple(nodes),
+            annotations=tuple(annotations),
+        )
         return ir_block, metrics
 
     # ------------------------------------------------------------------
@@ -269,7 +327,7 @@ class IRNormalizer:
                 continue
 
             if mnemonic == "return_values":
-                arity = self._return_arity(item)
+                arity = self._return_arity(item, items, index)
                 values = tuple(f"ret{i}" for i in range(arity))
                 items.replace_slice(index, index + 1, [IRReturn(values=values)])
                 metrics.returns += 1
@@ -301,7 +359,7 @@ class IRNormalizer:
         while index < len(items):
             item = items[index]
             if isinstance(item, RawInstruction) and item.mnemonic == "return_values":
-                arity = self._return_arity(item)
+                arity = self._return_arity(item, items, index)
                 values = tuple(f"ret{i}" for i in range(arity))
                 items.replace_slice(index, index + 1, [IRReturn(values=values)])
                 metrics.returns += 1
@@ -314,35 +372,59 @@ class IRNormalizer:
                 continue
             break
 
-    def _return_arity(self, instruction: RawInstruction) -> int:
+    def _return_arity(
+        self,
+        instruction: RawInstruction,
+        items: _ItemList | None = None,
+        index: int | None = None,
+    ) -> int:
         operand = instruction.operand
         lo = operand & 0xFF
         hi = (operand >> 8) & 0xFF
-        if lo:
+
+        if 0 < lo <= 16:
             return lo
-        if hi:
+        if 0 < hi <= 16:
             return hi
+
+        teardown = self._teardown_hint(items, index)
+        if teardown:
+            return teardown
+
+        mode_hint = instruction.profile.mode >> 4
+        if mode_hint:
+            return mode_hint
+
+        depth = instruction.event.depth_before
+        if depth:
+            return max(1, min(depth, 16))
+
         return 1
 
     def _pass_aggregates(self, items: _ItemList, metrics: NormalizerMetrics) -> None:
         index = 0
         while index < len(items):
             item = items[index]
-            if not isinstance(item, RawInstruction) or item.mnemonic != "push_literal":
+            if not isinstance(item, RawInstruction) or not self._is_literal_instruction(item):
                 index += 1
                 continue
 
             literal_instructions: List[RawInstruction] = []
             reducers: List[RawInstruction] = []
+            metadata: List[RawInstruction] = []
             scan = index
             while scan < len(items):
                 candidate = items[scan]
-                if isinstance(candidate, RawInstruction) and candidate.mnemonic == "push_literal":
+                if isinstance(candidate, RawInstruction) and self._is_literal_instruction(candidate):
                     literal_instructions.append(candidate)
                     scan += 1
                     continue
-                if isinstance(candidate, RawInstruction) and candidate.mnemonic.startswith("reduce"):
+                if isinstance(candidate, RawInstruction) and self._is_reduce_instruction(candidate):
                     reducers.append(candidate)
+                    scan += 1
+                    continue
+                if isinstance(candidate, RawInstruction) and self._is_metadata_instruction(candidate):
+                    metadata.append(candidate)
                     scan += 1
                     continue
                 break
@@ -352,6 +434,14 @@ class IRNormalizer:
                 continue
 
             literals = [self._describe_value(instr) for instr in literal_instructions]
+            expected_pairs = len(literals) // 2
+            if len(reducers) > expected_pairs:
+                excess = reducers[expected_pairs:]
+                metadata.extend(replace(instr, metadata_only=True) for instr in excess)
+                reducers = reducers[:expected_pairs]
+            if not reducers:
+                index += len(metadata) + 1
+                continue
             replacement: IRNode
             if len(literals) >= 2 and len(literals) == 2 * len(reducers):
                 entries = []
@@ -365,8 +455,8 @@ class IRNormalizer:
 
             metrics.aggregates += 1
             metrics.reduce_replaced += len(reducers)
-            items.replace_slice(index, scan, [replacement])
-            index += 1
+            items.replace_slice(index, scan, [*metadata, replacement])
+            index += len(metadata) + 1
 
     def _pass_branches(self, items: _ItemList, metrics: NormalizerMetrics) -> None:
         index = 0
@@ -377,7 +467,7 @@ class IRNormalizer:
                 continue
 
             if item.mnemonic == "testset_branch":
-                expr = self._describe_condition(items, index)
+                expr = self._describe_condition(items, index, prefer_expression=True)
                 node = IRTestSetBranch(
                     var=f"t{index}",
                     expr=expr,
@@ -427,6 +517,77 @@ class IRNormalizer:
     # ------------------------------------------------------------------
     # description helpers
     # ------------------------------------------------------------------
+    def _is_literal_instruction(self, instruction: RawInstruction) -> bool:
+        if instruction.mnemonic == "push_literal":
+            return True
+        if (
+            instruction.mnemonic.startswith("op_")
+            and instruction.annotations
+            and any(note in ANNOTATION_MNEMONICS for note in instruction.annotations)
+        ):
+            return False
+        if instruction.profile.kind in {InstructionKind.LITERAL, InstructionKind.PUSH}:
+            return instruction.pushes_value()
+        return False
+
+    @staticmethod
+    def _is_reduce_instruction(instruction: RawInstruction) -> bool:
+        if instruction.mnemonic.startswith("reduce"):
+            return True
+        return instruction.profile.kind is InstructionKind.REDUCE
+
+    def _is_metadata_instruction(self, instruction: RawInstruction) -> bool:
+        profile = instruction.profile
+        if instruction.metadata_only:
+            return True
+        if instruction.pushes_value() or instruction.event.popped_types:
+            if (
+                instruction.annotations
+                and any(note in ANNOTATION_MNEMONICS for note in instruction.annotations)
+                and instruction.mnemonic.startswith("op_")
+            ):
+                pass
+            else:
+                return False
+        if profile.mnemonic in ANNOTATION_MNEMONICS:
+            return True
+        if profile.is_literal_marker() and (
+            profile.mnemonic.startswith("op_") or profile.mnemonic == "literal_marker"
+        ):
+            return True
+        if instruction.annotations and any(note in ANNOTATION_MNEMONICS for note in instruction.annotations):
+            return True
+        if profile.kind is InstructionKind.ASCII_CHUNK:
+            return True
+        return False
+
+    def _metadata_entry(self, instruction: RawInstruction) -> Tuple[int, Tuple[str, ...]]:
+        labels: List[str] = []
+        if instruction.annotations:
+            labels.extend(instruction.annotations)
+        else:
+            labels.append(self._annotation_label(instruction.profile))
+        return instruction.offset, tuple(labels)
+
+    def _teardown_hint(self, items: _ItemList | None, index: int | None) -> int:
+        if items is None or index is None:
+            return 0
+        total = 0
+        scan = index - 1
+        while scan >= 0:
+            candidate = items[scan]
+            if not isinstance(candidate, RawInstruction):
+                break
+            if self._is_metadata_instruction(candidate):
+                scan -= 1
+                continue
+            if candidate.profile.kind is InstructionKind.STACK_TEARDOWN:
+                total += -candidate.event.delta
+                scan -= 1
+                continue
+            break
+        return total
+
     def _describe_value(self, instruction: RawInstruction) -> str:
         mnemonic = instruction.mnemonic
         operand = instruction.operand
@@ -438,16 +599,47 @@ class IRNormalizer:
             return f"slot(0x{operand:04X})"
         return instruction.describe_source()
 
-    def _describe_condition(self, items: _ItemList, index: int) -> str:
+    def _describe_condition(
+        self,
+        items: _ItemList,
+        index: int,
+        *,
+        prefer_expression: bool = False,
+    ) -> str:
         scan = index - 1
+        fallback: Optional[str] = None
         while scan >= 0:
             candidate = items[scan]
-            if isinstance(candidate, RawInstruction) and candidate.pushes_value():
-                return self._describe_value(candidate)
+            if isinstance(candidate, RawInstruction):
+                if candidate.pushes_value():
+                    value = self._describe_value(candidate)
+                    if prefer_expression and self._looks_like_literal(value):
+                        if fallback is None:
+                            fallback = value
+                        scan -= 1
+                        continue
+                    return value
+                if prefer_expression and candidate.profile.kind in {
+                    InstructionKind.CALL,
+                    InstructionKind.TAILCALL,
+                }:
+                    return candidate.describe_source()
             if isinstance(candidate, IRNode):
-                return getattr(candidate, "describe", lambda: "expr()")()
+                value = getattr(candidate, "describe", lambda: "expr()")()
+                if prefer_expression and self._looks_like_literal(value):
+                    if fallback is None:
+                        fallback = value
+                    scan -= 1
+                    continue
+                return value
             scan -= 1
+        if fallback is not None:
+            return fallback
         return "stack_top"
+
+    @staticmethod
+    def _looks_like_literal(description: str) -> bool:
+        return description.startswith("lit(")
 
     @staticmethod
     def _branch_target(instruction: RawInstruction) -> int:

--- a/mbcdisasm/ir/printer.py
+++ b/mbcdisasm/ir/printer.py
@@ -37,6 +37,9 @@ class IRTextRenderer:
 
     def _render_block(self, block: IRBlock) -> Iterable[str]:
         yield f"block {block.label} offset=0x{block.start_offset:06X}"
+        for offset, labels in block.annotations:
+            joined = ", ".join(labels)
+            yield f"  ; annotations 0x{offset:06X}: {joined}"
         for node in block.nodes:
             describe = getattr(node, "describe", None)
             if callable(describe):


### PR DESCRIPTION
## Summary
- capture literal markers and ASCII chunks as block annotations instead of executable IR nodes
- teach the aggregate pass to bridge metadata opcodes, mark stray reducers as annotations, and stabilise return/testset heuristics
- render block annotations in the textual IR so marker data is preserved outside the instruction stream

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0412b7fcc832fa724fe589fac0c18