### PR TITLE
Refine IR normalization for aggregates and returns

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -52,8 +52,13 @@ class IRReturn(IRNode):
     """Return from the current routine."""
 
     values: Tuple[str, ...]
+    varargs: bool = False
 
     def describe(self) -> str:
+        if self.varargs:
+            if self.values:
+                return f"return varargs({', '.join(self.values)})"
+            return "return varargs"
         values = ", ".join(self.values)
         return f"return [{values}]"
 
@@ -166,6 +171,7 @@ class IRBlock:
     label: str
     start_offset: int
     nodes: Tuple[IRNode, ...]
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/mbcdisasm/ir/printer.py
+++ b/mbcdisasm/ir/printer.py
@@ -37,6 +37,9 @@ class IRTextRenderer:
 
     def _render_block(self, block: IRBlock) -> Iterable[str]:
         yield f"block {block.label} offset=0x{block.start_offset:06X}"
+        if block.annotations:
+            for note in block.annotations:
+                yield f"  ; {note}"
         for node in block.nodes:
             describe = getattr(node, "describe", None)
             if callable(describe):


### PR DESCRIPTION
## Summary
- allow aggregate detection to skip literal marker helpers and fold trailing reducers into block annotations instead of leaving raw opcodes
- refine return arity inference with nibble-based heuristics, stack teardown hints, and vararg signalling so huge synthetic ret lists disappear
- treat testset branches as assignments to their target slot and surface parsed block annotations in the text renderer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0412b7fcc832fa724fe589fac0c18