### PR TITLE
Add stack shuffle and indirect pointer categories to opcode knowledge

### DIFF
--- a/knowledge/manual_annotations.json
+++ b/knowledge/manual_annotations.json
@@ -259,9 +259,18 @@
       "102:111"
     ]
   },
+  "stack_shuffle": {
+    "control_flow": "fallthrough",
+    "summary": "Чистые стековые перестановки и дублирования без побочных эффектов; количество элементов не меняется",
+    "category": "stack_copy_shuffle",
+    "stack_delta": 0
+  },
   "indirect_access": {
     "control_flow": "fallthrough",
     "summary": "Все формы indirect_fetch_slot / indirect_store_slot и их варианты. Семантика одна — косвенные загрузки и записи",
+    "category": "indirect_stack_access",
+    "stack_push": 1,
+    "stack_pop": 1,
     "opcodes": [
       "105:01",
       "105:16",
@@ -363,5 +372,15 @@
     "category": "call_helpers",
     "diapasone": "0x00–0xFF",
     "comment": "Вспомогательные вызовы с разными модами (00, 04, 64, 84, AC, D0 и др.)"
+  },
+  "66:*": {
+    "category": "stack_shuffle",
+    "diapasone": "0x00–0xFF",
+    "comment": "Все шифтеры 66:xx, которые переставляют/дублируют элементы стека без побочных эффектов"
+  },
+  "69:*": {
+    "category": "indirect_access",
+    "diapasone": "0x00–0xFF",
+    "comment": "Семейство 69:xx — косвенные обращения через адрес на вершине стека"
   }
 }

--- a/mbcdisasm/analyzer/instruction_profile.py
+++ b/mbcdisasm/analyzer/instruction_profile.py
@@ -203,7 +203,7 @@ class InstructionProfile:
             return True
 
         opcode = self.label.split(":", 1)[0]
-        if opcode in {"40", "67", "69"}:
+        if opcode in {"40", "67"}:
             return True
 
         return False

--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -44,7 +44,7 @@ def is_literal_marker(profile: InstructionProfile) -> bool:
         return True
 
     opcode = profile.label.split(":", 1)[0]
-    if opcode in {"40", "67", "69"}:
+    if opcode in {"40", "67"}:
         return True
     return False
 
@@ -1721,7 +1721,13 @@ class IndirectCallExSignature(SignatureRule):
             (
                 idx
                 for idx, profile in enumerate(profiles[lead_idx + 1 :], start=lead_idx + 1)
-                if is_literal_marker(profile) and profile.label.startswith("69:")
+                if profile.label.startswith("69:")
+                and profile.kind
+                in {
+                    InstructionKind.INDIRECT,
+                    InstructionKind.INDIRECT_LOAD,
+                    InstructionKind.INDIRECT_STORE,
+                }
             ),
             None,
         )

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -15,3 +15,20 @@ def test_wildcard_lookup_for_call_helpers():
     info = knowledge.lookup("16:84")
     assert info is not None
     assert info.control_flow and "call" in info.control_flow.lower()
+
+
+def test_wildcard_lookup_for_indirect_stack_access():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    info = knowledge.lookup("69:10")
+    assert info is not None
+    assert info.category and "indirect" in info.category
+    assert info.stack_push == 1
+    assert info.stack_pop == 1
+
+
+def test_wildcard_lookup_for_stack_shuffle():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    info = knowledge.lookup("66:20")
+    assert info is not None
+    assert info.category and "copy" in info.category
+    assert info.stack_effect() == 0

--- a/tests/test_stack_tracker.py
+++ b/tests/test_stack_tracker.py
@@ -64,3 +64,18 @@ def test_indirect_access_store_variant_detects_cleanup():
     assert indirect_event.delta == 0
     assert indirect_event.pushed_types == tuple()
     assert StackValueType.SLOT in indirect_event.popped_types
+
+
+def test_stack_shuffle_preserves_depth():
+    words = [
+        make_word(0x00, 0x00, 0x0001, 0),
+        make_word(0x00, 0x00, 0x0002, 4),
+        make_word(0x66, 0x10, 0x0000, 8),
+    ]
+    profiles = load_profiles(words)
+    tracker = StackTracker()
+    events = tracker.process_sequence(profiles)
+
+    shuffle_event = events[-1]
+    assert shuffle_event.kind is InstructionKind.STACK_COPY
+    assert shuffle_event.delta == 0


### PR DESCRIPTION
## Summary
- classify 66:* helpers as stack shuffles with zero stack delta and expose them through the knowledge base
- extend the indirect access annotations with stack effects and map the full 69:* family onto the new category
- adjust literal marker heuristics, pipeline signatures, and tests to reflect the new opcode semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e056510d6c832f89e0e0cbeb3ece4f