### PR TITLE
Refine IR branch condition handling

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -40,11 +40,13 @@ class IRCall(IRNode):
     target: int
     args: Tuple[str, ...]
     tail: bool = False
+    result: str | None = None
 
     def describe(self) -> str:
         suffix = " tail" if self.tail else ""
         args = ", ".join(self.args)
-        return f"call{suffix} target=0x{self.target:04X} args=[{args}]"
+        prefix = f"{self.result} = " if self.result else ""
+        return f"{prefix}call{suffix} target=0x{self.target:04X} args=[{args}]"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- allow IR calls to capture result bindings for reuse in subsequent predicates
- normalise branch conditions by skipping inline ASCII chunks and introducing temporaries for call results
- extend the IR normaliser tests with scenarios covering call-driven predicates and inline ASCII data

## Testing
- pytest tests/test_ir_normalizer.py

------
https://chatgpt.com/codex/tasks/task_e_68e0629a098c832f9482414b4160fb7c