### PR TITLE
Refine IR branch predicate handling and ASCII data labelling

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 class MemSpace(Enum):
@@ -40,11 +40,13 @@ class IRCall(IRNode):
     target: int
     args: Tuple[str, ...]
     tail: bool = False
+    result: Optional[str] = None
 
     def describe(self) -> str:
         suffix = " tail" if self.tail else ""
         args = ", ".join(self.args)
-        return f"call{suffix} target=0x{self.target:04X} args=[{args}]"
+        prefix = f"{self.result} = " if self.result else ""
+        return f"{prefix}call{suffix} target=0x{self.target:04X} args=[{args}]"
 
 
 @dataclass(frozen=True)
@@ -209,6 +211,7 @@ class IRBlock:
     start_offset: int
     nodes: Tuple[IRNode, ...]
     annotations: Tuple[str, ...] = field(default_factory=tuple)
+    data_block: bool = False
 
 
 @dataclass(frozen=True)

--- a/mbcdisasm/ir/printer.py
+++ b/mbcdisasm/ir/printer.py
@@ -37,6 +37,8 @@ class IRTextRenderer:
 
     def _render_block(self, block: IRBlock) -> Iterable[str]:
         yield f"block {block.label} offset=0x{block.start_offset:06X}"
+        if block.data_block:
+            yield "  ; classified as data"
         if block.annotations:
             for note in block.annotations:
                 yield f"  ; {note}"


### PR DESCRIPTION
## Summary
- allow IR calls to capture explicit result names so branch predicates no longer inline the call expression
- ignore ASCII literal chunks when deriving branch conditions and classify blocks composed of ASCII payloads as data
- surface the new data classification in the text renderer and cover the changes with targeted IR normaliser tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e064c4f800832fa52c43160eb6f2fe