### PR TITLE
Refine IR branch predicate handling

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 class MemSpace(Enum):
@@ -40,11 +40,15 @@ class IRCall(IRNode):
     target: int
     args: Tuple[str, ...]
     tail: bool = False
+    result: Optional[str] = None
 
     def describe(self) -> str:
         suffix = " tail" if self.tail else ""
         args = ", ".join(self.args)
-        return f"call{suffix} target=0x{self.target:04X} args=[{args}]"
+        base = f"call{suffix} target=0x{self.target:04X} args=[{args}]"
+        if self.result:
+            return f"{self.result} = {base}"
+        return base
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- assign temporary result names to calls referenced by branch predicates so that the IR no longer embeds call descriptions directly in the condition
- skip inline ASCII chunks when resolving branch predicates and carry the temporary name on `IRCall` nodes
- extend the IR normaliser tests to cover the new behaviour and add fixture data for direct calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e064c4f800832fa52c43160eb6f2fe