### PR TITLE
Normalize 0x66 stack shaping instructions

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -187,6 +187,29 @@ class IRStore(IRNode):
 
 
 @dataclass(frozen=True)
+class IRStackDuplicate(IRNode):
+    """Duplicate the value currently at the top of the VM stack."""
+
+    value: str
+    copies: int = 2
+
+    def describe(self) -> str:
+        if self.copies <= 1:
+            return f"dup {self.value}"
+        return f"dup {self.value} -> copies={self.copies}"
+
+
+@dataclass(frozen=True)
+class IRStackDrop(IRNode):
+    """Discard the value currently residing at the top of the VM stack."""
+
+    value: str
+
+    def describe(self) -> str:
+        return f"drop {self.value}"
+
+
+@dataclass(frozen=True)
 class IRRaw(IRNode):
     """Fallback wrapper for instructions that have not been normalised."""
 
@@ -296,6 +319,8 @@ __all__ = [
     "IRTestSetBranch",
     "IRLoad",
     "IRStore",
+    "IRStackDuplicate",
+    "IRStackDrop",
     "IRLiteral",
     "IRLiteralChunk",
     "IRSlot",


### PR DESCRIPTION
## Summary
- add dedicated IR nodes for stack duplication and drop operations
- translate 0x66 stack shaper opcodes into explicit IR nodes and reuse IRLoad for slot copies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e066140118832fb524b6cbe820f867