### PR TITLE
Enhance ASCII detection and collapse runs

### DIFF
--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,3 +1,4 @@
+import struct
 from pathlib import Path
 
 from mbcdisasm import KnowledgeBase
@@ -31,6 +32,16 @@ def test_ascii_detection_marks_inline_chunk():
     assert profile.mnemonic == "inline_ascii_chunk"
     assert profile.kind is InstructionKind.ASCII_CHUNK
     assert profile.traits.get("heuristic")
+
+
+def test_ascii_detection_accepts_wide_pairs():
+    wide_be = InstructionWord(0, int.from_bytes(b"\x00A\x00B", "big"))
+    wide_le = InstructionWord(4, int.from_bytes(b"A\x00B\x00", "big"))
+    pair_le = InstructionWord(8, int.from_bytes(struct.pack("<HH", 0x4142, 0x4344), "big"))
+
+    assert looks_like_ascii_chunk(wide_be)
+    assert looks_like_ascii_chunk(wide_le)
+    assert looks_like_ascii_chunk(pair_le)
 
 
 def test_signature_detector_matches_ascii_run():


### PR DESCRIPTION
## Summary
- extend the ASCII classification heuristics to cover 16-bit style pairs and ensure call metadata is respected
- introduce literal marker hints and an ASCII run coalescing pass in the IR normaliser, including support for rebuilding headers from merged chunks
- add regression tests for the new ASCII detection cases and the literal hint/ASCII run handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e14c6d819c832f8d747d136ab6ea82