### PR TITLE
Improve ASCII heuristics and literal promotion

### DIFF
--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -33,6 +33,16 @@ def test_ascii_detection_marks_inline_chunk():
     assert profile.traits.get("heuristic")
 
 
+def test_ascii_detection_handles_wide_pairs():
+    word = InstructionWord(0, int.from_bytes(b"A\x00B\x00", "big"))
+    assert looks_like_ascii_chunk(word)
+
+
+def test_ascii_detection_handles_swapped_pairs():
+    word = InstructionWord(0, int.from_bytes(b"\x00C\x00D", "big"))
+    assert looks_like_ascii_chunk(word)
+
+
 def test_signature_detector_matches_ascii_run():
     knowledge = KnowledgeBase({})
     words = [


### PR DESCRIPTION
## Summary
- tighten ASCII chunk detection to cover 16-bit carriers and recognise call metadata from manual annotations
- add greedy pass to turn heuristic ASCII runs into literal chunks and promote stable literal operands
- extend unit tests for analyser and normaliser to cover the new heuristics

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e14c6d819c832f8d747d136ab6ea82