### PR TITLE
Improve IR normalization for tailcalls and frame handling

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -359,6 +359,17 @@ class IRStackDrop(IRNode):
 
 
 @dataclass(frozen=True)
+class IRStackTeardown(IRNode):
+    """Collapse the dedicated stack teardown helpers into a canonical node."""
+
+    count: int
+    operand: int
+
+    def describe(self) -> str:
+        return f"stack_teardown count={self.count} operand=0x{self.operand:04X}"
+
+
+@dataclass(frozen=True)
 class IRAsciiHeader(IRNode):
     """Captures dense ASCII banners embedded at block boundaries."""
 
@@ -505,6 +516,7 @@ __all__ = [
     "IRStore",
     "IRStackDuplicate",
     "IRStackDrop",
+    "IRStackTeardown",
     "IRAsciiHeader",
     "IRCallReturn",
     "IRLiteral",


### PR DESCRIPTION
## Summary
- demote tail calls when their result is branched on and treat ASCII finalizers as semantic no-ops
- normalize stack teardown helpers and broaden function prologue detection to absorb common setup sequences
- extend the IR normalizer tests to cover the new control-flow handling and teardown representation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e167ad2740832fbb4f7a8dd3cc19ed