### PR TITLE
Normalize tail-guarded branches and stack teardowns

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -359,6 +359,17 @@ class IRStackDrop(IRNode):
 
 
 @dataclass(frozen=True)
+class IRStackTeardown(IRNode):
+    """Canonical representation for explicit stack teardown helpers."""
+
+    count: int
+    operand: int
+
+    def describe(self) -> str:
+        return f"stack_teardown count={self.count} operand=0x{self.operand:04X}"
+
+
+@dataclass(frozen=True)
 class IRAsciiHeader(IRNode):
     """Captures dense ASCII banners embedded at block boundaries."""
 
@@ -505,6 +516,7 @@ __all__ = [
     "IRStore",
     "IRStackDuplicate",
     "IRStackDrop",
+    "IRStackTeardown",
     "IRAsciiHeader",
     "IRCallReturn",
     "IRLiteral",


### PR DESCRIPTION
## Summary
- convert stack teardown instructions into explicit IR nodes and reuse them when collapsing tail returns
- materialise tail-dispatched calls that feed conditional branches and treat ASCII finalizers as semantic no-ops when walking operands
- extend the IR normalizer tests to cover call-driven predicates and the new stack teardown representation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e167ad2740832fbb4f7a8dd3cc19ed