### PR TITLE
Add IR boolean nodes and normalize predicate usage

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -193,6 +193,39 @@ class IRTailcallAscii(IRNode):
 
 
 @dataclass(frozen=True)
+class IRCompare(IRNode):
+    """Boolean comparison of two stack values."""
+
+    result: str
+    left: str
+    right: str
+    operator: str
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
+
+    def describe(self) -> str:
+        suffix = ""
+        if self.annotations:
+            suffix = " " + ", ".join(self.annotations)
+        return f"cmp {self.result}={self.left} {self.operator} {self.right}{suffix}"
+
+
+@dataclass(frozen=True)
+class IRTest(IRNode):
+    """Unary boolean test applied to a stack value."""
+
+    result: str
+    value: str
+    operator: str
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
+
+    def describe(self) -> str:
+        suffix = ""
+        if self.annotations:
+            suffix = " " + ", ".join(self.annotations)
+        return f"test {self.result}={self.operator}({self.value}){suffix}"
+
+
+@dataclass(frozen=True)
 class IRIf(IRNode):
     """Standard conditional branch."""
 
@@ -497,6 +530,8 @@ __all__ = [
     "IRLiteralBlock",
     "IRAsciiWrapperCall",
     "IRTailcallAscii",
+    "IRCompare",
+    "IRTest",
     "IRIf",
     "IRTestSetBranch",
     "IRFlagCheck",


### PR DESCRIPTION
## Summary
- add dedicated `IRCompare` and `IRTest` nodes for boolean expressions and expose them through the IR API
- extend the normalizer to record SSA names for logical/test instructions, build predicate nodes, and reuse them in branch lowering
- update IR normalizer tests with boolean scenarios and supporting manual metadata entries

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e1b9805f20832fbe7c0a0b93c08777