### PR TITLE
Add IR predicate nodes and normalize compare/test instructions

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -208,6 +208,34 @@ class IRIf(IRNode):
 
 
 @dataclass(frozen=True)
+class IRCompare(IRNode):
+    """Explicit comparison producing a boolean predicate."""
+
+    result: str
+    operator: str
+    lhs: str
+    rhs: str
+
+    def describe(self) -> str:
+        return (
+            f"compare {self.result}={self.operator}({self.lhs}, {self.rhs})"
+        )
+
+
+@dataclass(frozen=True)
+class IRTest(IRNode):
+    """Logical or unary test operation producing a predicate."""
+
+    result: str
+    operator: str
+    operands: Tuple[str, ...]
+
+    def describe(self) -> str:
+        rendered = ", ".join(self.operands)
+        return f"test {self.result}={self.operator}([{rendered}])"
+
+
+@dataclass(frozen=True)
 class IRTestSetBranch(IRNode):
     """Branch that stores the predicate before testing it."""
 
@@ -501,6 +529,8 @@ __all__ = [
     "IRTestSetBranch",
     "IRFlagCheck",
     "IRFunctionPrologue",
+    "IRCompare",
+    "IRTest",
     "IRLoad",
     "IRStore",
     "IRStackDuplicate",


### PR DESCRIPTION
## Summary
- add IRCompare and IRTest nodes to represent boolean-producing instructions with SSA metadata
- extend the normalizer to record predicate operations and reuse their results when building branches
- expand IR normalizer tests with artificial predicate sequences to verify the new nodes and metrics

## Testing
- pytest tests/test_ir_normalizer.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b9805f20832fbe7c0a0b93c08777