### PR TITLE
Improve call stack normalization

### DIFF
--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -390,6 +390,70 @@ def test_normalizer_inlines_call_preparation_shuffle(tmp_path: Path) -> None:
     )
 
 
+def test_normalizer_call_preparation_skips_noise(tmp_path: Path) -> None:
+    knowledge = write_manual(tmp_path)
+
+    words = [
+        build_word(0, 0x00, 0x00, 0x1111),  # push_literal noise
+        build_word(4, 0x66, 0x15, 0x4B08),  # stack_shuffle
+        build_word(8, 0x00, 0x38, 0x0000),  # literal_marker noise
+        build_word(12, 0x01, 0xF0, 0x0000),  # stack_teardown_4
+        build_word(16, 0x28, 0x00, 0x1234),  # call_dispatch
+        build_word(20, 0x30, 0x00, 0x0000),  # return_values
+    ]
+
+    data = encode_instructions(words)
+    descriptor = SegmentDescriptor(0, 0, len(data))
+    segment = Segment(descriptor, data)
+    container = MbcContainer(Path("dummy"), [segment])
+
+    normalizer = IRNormalizer(knowledge)
+    program = normalizer.normalise_container(container)
+    block = program.segments[0].blocks[0]
+
+    prep = next(node for node in block.nodes if isinstance(node, IRCallPreparation))
+    assert prep.steps == (("stack_shuffle", 0x4B08), ("stack_teardown", 4))
+
+    assert not any(
+        isinstance(node, IRRaw)
+        and node.mnemonic in {"stack_shuffle", "stack_teardown_4"}
+        for node in block.nodes
+    )
+
+
+def test_normalizer_call_cleanup_skips_noise(tmp_path: Path) -> None:
+    knowledge = write_manual(tmp_path)
+
+    words = [
+        build_word(0, 0x28, 0x00, 0x1234),  # call_dispatch
+        build_word(4, 0x10, 0xE8, 0x0001),  # call_helpers
+        build_word(8, 0x00, 0x38, 0x0000),  # literal_marker noise
+        build_word(12, 0x01, 0xF0, 0x0000),  # stack_teardown_4
+        build_word(16, 0x30, 0x00, 0x0001),  # return_values
+    ]
+
+    data = encode_instructions(words)
+    descriptor = SegmentDescriptor(0, 0, len(data))
+    segment = Segment(descriptor, data)
+    container = MbcContainer(Path("dummy"), [segment])
+
+    normalizer = IRNormalizer(knowledge)
+    program = normalizer.normalise_container(container)
+    block = program.segments[0].blocks[0]
+
+    ret = next(node for node in block.nodes if isinstance(node, IRReturn))
+    assert [step.mnemonic for step in ret.cleanup] == [
+        "call_helpers",
+        "stack_teardown",
+    ]
+    assert ret.cleanup[-1].pops == 4
+
+    assert not any(
+        isinstance(node, IRRaw) and node.mnemonic.startswith("stack_teardown")
+        for node in block.nodes
+    )
+
+
 def test_normalizer_attaches_epilogue_to_return(tmp_path: Path) -> None:
     knowledge = write_manual(tmp_path)
 
@@ -410,6 +474,34 @@ def test_normalizer_attaches_epilogue_to_return(tmp_path: Path) -> None:
     ret = next(node for node in block.nodes if isinstance(node, IRReturn))
     assert ret.cleanup and ret.cleanup[0].mnemonic == "stack_teardown"
     assert ret.cleanup[0].pops == 4
+    assert not any(
+        isinstance(node, IRRaw) and node.mnemonic.startswith("stack_teardown")
+        for node in block.nodes
+    )
+
+
+def test_normalizer_return_epilogue_skips_noise(tmp_path: Path) -> None:
+    knowledge = write_manual(tmp_path)
+
+    words = [
+        build_word(0, 0x01, 0xF0, 0x0000),  # stack_teardown_4
+        build_word(4, 0x00, 0x38, 0x0000),  # literal_marker noise
+        build_word(8, 0x30, 0x00, 0x0002),  # return_values
+    ]
+
+    data = encode_instructions(words)
+    descriptor = SegmentDescriptor(0, 0, len(data))
+    segment = Segment(descriptor, data)
+    container = MbcContainer(Path("dummy"), [segment])
+
+    normalizer = IRNormalizer(knowledge)
+    program = normalizer.normalise_container(container)
+    block = program.segments[0].blocks[0]
+
+    ret = next(node for node in block.nodes if isinstance(node, IRReturn))
+    assert ret.cleanup and ret.cleanup[0].mnemonic == "stack_teardown"
+    assert ret.cleanup[0].pops == 4
+
     assert not any(
         isinstance(node, IRRaw) and node.mnemonic.startswith("stack_teardown")
         for node in block.nodes


### PR DESCRIPTION
## Summary
- teach the call preparation pass to merge stack shuffles/teardowns even when interleaved with benign literals or existing summaries
- extend call cleanup handling to absorb teardown sequences around calls and returns despite noisy instructions, consolidating them into structured epilogues
- add regression tests that cover noisy call preparation and cleanup scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c5fa1a94832fa9696b4748c9fc6e