### PR TITLE
Improve indirect access modelling and symbol naming

### DIFF
--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -244,8 +244,10 @@ def test_normalizer_builds_ir(tmp_path: Path) -> None:
         text.startswith("testset") or text.startswith("function_prologue")
         for text in descriptions
     )
-    assert any(text.startswith("load") for text in descriptions)
-    assert any(text.startswith("store") for text in descriptions)
+    assert any(text.startswith("indirect_load") for text in descriptions)
+    assert any(text.startswith("load") or text.startswith("indirect_load") for text in descriptions)
+    assert any(text.startswith("store") or text.startswith("indirect_store") for text in descriptions)
+    assert any("addr(" in text for text in descriptions)
 
     renderer = IRTextRenderer()
     text = renderer.render(program)


### PR DESCRIPTION
## Summary
- propagate SSA value kinds through the normaliser and introduce address-aware memory symbols
- render literal addresses and indirect loads/stores via dedicated IR nodes with readable annotations
- update normaliser tests to cover the new indirect access and address formatting behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e2cbedf3a4832f8610fc6609e0edae