### PR TITLE
Introduce symbolic memrefs for indirect accesses

### DIFF
--- a/mbcdisasm/ir/__init__.py
+++ b/mbcdisasm/ir/__init__.py
@@ -33,6 +33,7 @@ from .model import (
     IRIf,
     IRFunctionPrologue,
     MemSpace,
+    MemRef,
     NormalizerMetrics,
 )
 from .normalizer import IRNormalizer
@@ -70,6 +71,7 @@ __all__ = [
     "IRTailcallFrame",
     "IRTablePatch",
     "IRSlot",
+    "MemRef",
     "IRRaw",
     "MemSpace",
     "NormalizerMetrics",


### PR DESCRIPTION
## Summary
- add a MemRef model and normalizer pass that fuses raw ladder opcodes with neighbouring indirect loads/stores into symbolic addresses
- promote pointer SSA values to a ptr prefix and assign heuristic names for repeated bank/page/off combinations
- extend the IR normalizer test fixture to cover the new ladder pattern and memref rendering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2cbedf3a4832f8610fc6609e0edae