### PR TITLE
Refine IR address handling and centralise literal resources

### DIFF
--- a/mbcdisasm/ir/printer.py
+++ b/mbcdisasm/ir/printer.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
-from .model import IRBlock, IRProgram, IRSegment
+from .model import IRBlock, IRProgram, IRResourceSection, IRSegment
 
 
 class IRTextRenderer:
@@ -14,6 +14,8 @@ class IRTextRenderer:
     def render(self, program: IRProgram) -> str:
         lines: List[str] = []
         lines.append("; normalizer metrics: " + program.metrics.describe())
+        if program.resources:
+            lines.extend(self._render_resources(program.resources))
         for segment in program.segments:
             lines.extend(self._render_segment(segment))
         return "\n".join(lines) + "\n"
@@ -24,6 +26,14 @@ class IRTextRenderer:
     # ------------------------------------------------------------------
     # helpers
     # ------------------------------------------------------------------
+    def _render_resources(self, sections: Tuple["IRResourceSection", ...]) -> Iterable[str]:
+        yield "; resources:"
+        for section in sections:
+            yield f";   section {section.name}"
+            for entry in section.entries:
+                summary = entry.describe()
+                yield f";     {summary}"
+
     def _render_segment(self, segment: IRSegment) -> Iterable[str]:
         header = (
             f"; segment {segment.index} offset=0x{segment.start:06X} "

--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -335,7 +335,9 @@ def test_normalizer_collapses_ascii_runs_and_literal_hints(tmp_path: Path) -> No
 
     descriptions = [getattr(node, "describe", lambda: "")() for node in block.nodes]
 
-    assert "ascii_header[ascii(A\\x00B\\x00), ascii(\\x00C\\x00D)]" in descriptions
+    header = next(text for text in descriptions if text.startswith("ascii_header["))
+    assert "ascii(A\\x00B\\x00)" in header
+    assert "ascii(\\x00C\\x00D)" in header
     assert "lit(0x6704)" in descriptions
 
 def test_raw_instruction_renders_operand_alias(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add typed address helpers and update indirect load/store nodes to carry banked, stack, and IO address metadata
- centralise ASCII and literal-marker blobs into resource sections that IR nodes reference, and render the new sections in the text printer
- register literal and ASCII data during normalisation via a resource registry and update tests for the resource-aware header format

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e3bb965e80832f92562d1c3492882c