### PR TITLE
Refine IR address typing and resource tracking

### DIFF
--- a/mbcdisasm/ir/printer.py
+++ b/mbcdisasm/ir/printer.py
@@ -14,6 +14,15 @@ class IRTextRenderer:
     def render(self, program: IRProgram) -> str:
         lines: List[str] = []
         lines.append("; normalizer metrics: " + program.metrics.describe())
+        if program.resources:
+            lines.append("; resources:")
+            for section in program.resources:
+                header = (
+                    f";   section {section.kind} count={len(section.resources)}"
+                )
+                lines.append(header)
+                for resource in section.resources:
+                    lines.append(f";     {resource.describe()}")
         for segment in program.segments:
             lines.extend(self._render_segment(segment))
         return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- introduce dedicated IR address classes and explicit addr_cast nodes so indirect loads/stores track banked, stack and global spaces
- promote ASCII chunks and literal marker sequences into shared resource sections referenced via IRResourceRef and render them in IR output
- update IR normalizer tests to cover resource collection and the new banked load formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3bb965e80832f92562d1c3492882c