### PR TITLE
Normalize call context and tail symbols in IR

### DIFF
--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from mbcdisasm import KnowledgeBase
@@ -15,3 +16,14 @@ def test_wildcard_lookup_for_call_helpers():
     info = knowledge.lookup("16:84")
     assert info is not None
     assert info.control_flow and "call" in info.control_flow.lower()
+
+
+def test_address_symbol_lookup(tmp_path):
+    manual_path = tmp_path / "manual_annotations.json"
+    manual_path.write_text(json.dumps({}, indent=2), "utf-8")
+    address_path = tmp_path / "address_labels.json"
+    address_path.write_text(json.dumps({"0x10": "helper_0010"}, indent=2), "utf-8")
+
+    knowledge = KnowledgeBase.load(manual_path)
+    assert knowledge.address_symbol(0x0010) == "helper_0010"
+    assert knowledge.address_symbol(0x0020) is None


### PR DESCRIPTION
## Summary
- attach call preparation shuffles and cleanup masks directly to IR call nodes, recording arity and optional tail markers
- load optional address label tables so tailcall targets render as symbols in the IR
- refresh tests to cover the richer call representation and address label lookups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3cafaff88832fbae0f41b2c76fcb6