### PR TITLE
Fold call preludes into signatures and lift predicates

### DIFF
--- a/knowledge/call_signatures.json
+++ b/knowledge/call_signatures.json
@@ -5,6 +5,37 @@
     "cleanup": [
       {"mnemonic": "stack_teardown", "pops": 1}
     ],
+    "prelude": [
+      {
+        "kind": "raw",
+        "mnemonic": "op_F0_4B",
+        "effect": {
+          "mnemonic": "op_F0_4B",
+          "inherit_operand": true,
+          "inherit_alias": true
+        }
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_5E_29",
+        "effect": {
+          "mnemonic": "op_5E_29",
+          "inherit_operand": true,
+          "inherit_alias": true
+        },
+        "cleanup_mask": "0x2910"
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_6C_01",
+        "effect": {
+          "mnemonic": "op_6C_01",
+          "inherit_operand": true,
+          "inherit_alias": true
+        }
+      }
+    ],
+    "shuffle": "0x4B08",
     "shuffle_options": ["0x4B08", "0x3032", "0x7223"],
     "postlude": [
       {


### PR DESCRIPTION
## Summary
- fold the shared 0x6C/0x5E/0xF0 prologue into the 0x0072 helper signature and canonicalise its shuffle mask
- teach the normaliser to merge RET_MASK followed by return into call_return nodes while lifting trailing predicates onto the call
- extend IR normaliser tests to cover the new contracts, shuffle behaviour, and predicate attachment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e926e838832f9d6a1895ed0714bd