### PR TITLE
Normalize helper call prologues and lift branch predicates

### DIFF
--- a/knowledge/call_signatures.json
+++ b/knowledge/call_signatures.json
@@ -5,15 +5,29 @@
     "cleanup": [
       {"mnemonic": "stack_teardown", "pops": 1}
     ],
+    "shuffle": "0x4B08",
     "shuffle_options": ["0x4B08", "0x3032", "0x7223"],
-    "postlude": [
+    "prelude": [
       {
         "kind": "raw",
-        "mnemonic": "op_29_10",
-        "operand": "0x2910",
-        "cleanup_mask": "0x2910",
-        "tail": true
+        "mnemonic": "op_F0_4B",
+        "operand": "0x4B08",
+        "effect": {"mnemonic": "op_F0_4B", "operand": "0x4B08"}
       },
+      {
+        "kind": "raw",
+        "mnemonic": "op_5E_29",
+        "operand": "0x2910",
+        "effect": {"mnemonic": "op_5E_29", "operand": "0x2910"}
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_6C_01",
+        "operand": "0x6C01",
+        "effect": {"mnemonic": "op_6C_01", "operand": "0x6C01"}
+      }
+    ],
+    "postlude": [
       {
         "kind": "raw",
         "mnemonic": "op_70_29",
@@ -31,8 +45,7 @@
         "mnemonic": "op_06_66",
         "effect": {"mnemonic": "op_06_66", "inherit_operand": true},
         "optional": true
-      },
-      {"kind": "testset", "optional": true}
+      }
     ]
   }
 }

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Optional, Tuple
 
+from ..constants import OPERAND_ALIASES
+
 
 class MemSpace(Enum):
     """High level classification of indirect memory accesses."""
@@ -125,9 +127,9 @@ class IRCall(IRNode):
         if self.arity is not None:
             details.append(f"arity={self.arity}")
         if self.shuffle is not None:
-            details.append(f"shuffle=0x{self.shuffle:04X}")
+            details.append(f"shuffle={_format_operand(self.shuffle)}")
         if self.cleanup_mask is not None:
-            details.append(f"mask=0x{self.cleanup_mask:04X}")
+            details.append(f"mask={_format_operand(self.cleanup_mask)}")
         if self.cleanup:
             rendered = ", ".join(step.describe() for step in self.cleanup)
             details.append(f"cleanup=[{rendered}]")
@@ -315,9 +317,9 @@ class IRAsciiWrapperCall(IRNode):
         if self.arity is not None:
             details.append(f"arity={self.arity}")
         if self.shuffle is not None:
-            details.append(f"shuffle=0x{self.shuffle:04X}")
+            details.append(f"shuffle={_format_operand(self.shuffle)}")
         if self.cleanup_mask is not None:
-            details.append(f"mask=0x{self.cleanup_mask:04X}")
+            details.append(f"mask={_format_operand(self.cleanup_mask)}")
         if self.cleanup:
             rendered = ", ".join(step.describe() for step in self.cleanup)
             details.append(f"cleanup=[{rendered}]")
@@ -356,9 +358,9 @@ class IRTailcallAscii(IRNode):
         if self.arity is not None:
             details.append(f"arity={self.arity}")
         if self.shuffle is not None:
-            details.append(f"shuffle=0x{self.shuffle:04X}")
+            details.append(f"shuffle={_format_operand(self.shuffle)}")
         if self.cleanup_mask is not None:
-            details.append(f"mask=0x{self.cleanup_mask:04X}")
+            details.append(f"mask={_format_operand(self.cleanup_mask)}")
         if self.cleanup:
             rendered = ", ".join(step.describe() for step in self.cleanup)
             details.append(f"cleanup=[{rendered}]")
@@ -646,9 +648,9 @@ class IRCallReturn(IRNode):
         if self.arity is not None:
             details.append(f"arity={self.arity}")
         if self.shuffle is not None:
-            details.append(f"shuffle=0x{self.shuffle:04X}")
+            details.append(f"shuffle={_format_operand(self.shuffle)}")
         if self.cleanup_mask is not None:
-            details.append(f"mask=0x{self.cleanup_mask:04X}")
+            details.append(f"mask={_format_operand(self.cleanup_mask)}")
         if self.predicate is not None:
             details.append(f"predicate={self.predicate.describe()}")
         extra = f" {' '.join(details)}" if details else ""
@@ -814,3 +816,16 @@ __all__ = [
     "SSAValueKind",
     "NormalizerMetrics",
 ]
+
+
+def _format_operand(value: int) -> str:
+    hex_value = f"0x{value:04X}"
+    alias = OPERAND_ALIASES.get(value)
+    if alias:
+        alias_text = alias if isinstance(alias, str) else str(alias)
+        upper = alias_text.upper()
+        if upper.startswith("0X"):
+            alias_text = upper
+        return alias_text if alias_text == hex_value else f"{alias_text}({hex_value})"
+    return hex_value
+


### PR DESCRIPTION
## Summary
- fold the common 0x6C/0x5E/0xF0 helper prologue into the 0x0072 call signature and normalise shuffle output
- render call and wrapper metadata with operand aliases for masks and shuffles
- collapse RET_MASK + return sequences, attach post-call predicates, and keep branches clean while updating tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e926e838832f9d6a1895ed0714bd