### PR TITLE
Expand IO folding and refine memory aliases

### DIFF
--- a/mbcdisasm/constants.py
+++ b/mbcdisasm/constants.py
@@ -13,6 +13,7 @@ from typing import Dict
 # which makes it hard to reason about them in isolation.
 RET_MASK = 0x2910
 IO_SLOT = 0x6910
+IO_PORT_NAME = "io.port_6910"
 PAGE_REGISTER = 0x6C01
 FANOUT_FLAGS_A = 0x2C02
 FANOUT_FLAGS_B = 0x2C03
@@ -29,12 +30,40 @@ OPERAND_ALIASES: Dict[int, str] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Memory layout aliases
+# ---------------------------------------------------------------------------
+
+# Selected helper banks that appear throughout the control helpers.  The low
+# nybble in the runtime stream is frequently repurposed for sub-banks.  To keep
+# the output stable we normalise the value before applying the alias.
+MEMORY_BANK_ALIASES = {
+    0x4B00: "sys.table.base",
+    0x4B10: "sys.helper",
+    0x4B50: "sys.table.meta",
+    0x4B80: "sys.table.rows",
+    0x4BC0: "sys.table.patch",
+    0x4BD0: "sys.table.cache",
+    0x3D30: "io.helpers",
+    0x3D60: "io.buffers",
+}
+
+# Frequently accessed pages get a shorter alias to make the rendered memory
+# references easier to read in complex table dispatch blocks.
+MEMORY_PAGE_ALIASES = {
+    (0x3D30, 0xDC): "io",
+}
+
+
 __all__ = [
     "RET_MASK",
     "IO_SLOT",
+    "IO_PORT_NAME",
     "PAGE_REGISTER",
     "FANOUT_FLAGS_A",
     "FANOUT_FLAGS_B",
     "CALL_SHUFFLE_STANDARD",
     "OPERAND_ALIASES",
+    "MEMORY_BANK_ALIASES",
+    "MEMORY_PAGE_ALIASES",
 ]

--- a/mbcdisasm/ir/__init__.py
+++ b/mbcdisasm/ir/__init__.py
@@ -35,6 +35,8 @@ from .model import (
     IRIf,
     IRFunctionPrologue,
     IRConditionMask,
+    IRIORead,
+    IRIOWrite,
     MemSpace,
     NormalizerMetrics,
 )
@@ -68,6 +70,8 @@ __all__ = [
     "IRCallCleanup",
     "IRLoad",
     "IRStore",
+    "IRIORead",
+    "IRIOWrite",
     "IRStackDuplicate",
     "IRStackDrop",
     "IRStackEffect",


### PR DESCRIPTION
## Summary
- widen IO handshake matching so op_3D/31_30 sequences fold into io.read/io.write even across intermediate helper calls
- add descriptive aliases for the system table and IO buffer memory families to simplify rendered memrefs
- extend the normalizer tests to cover the expanded IO folding logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3fc922524832f83adb9e93b3f33f4