### PR TITLE
Improve stack heuristics for call wrapper pipelines

### DIFF
--- a/tests/test_stack_tracker.py
+++ b/tests/test_stack_tracker.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from mbcdisasm import KnowledgeBase
 from mbcdisasm.analyzer.instruction_profile import InstructionKind, InstructionProfile
 from mbcdisasm.analyzer.stack import StackTracker, StackValueType
+from mbcdisasm.constants import CALL_SHUFFLE_STANDARD, RET_MASK
 from mbcdisasm.instruction import InstructionWord
 
 
@@ -64,3 +65,49 @@ def test_indirect_access_store_variant_detects_cleanup():
     assert indirect_event.delta == 0
     assert indirect_event.pushed_types == tuple()
     assert StackValueType.SLOT in indirect_event.popped_types
+
+
+def test_call_helper_wrapper_has_stable_stack_model():
+    words = [
+        make_word(0x66, 0x15, CALL_SHUFFLE_STANDARD, 0),
+        make_word(0x4A, 0x05, 0x0052, 4),
+        make_word(0x28, 0x00, 0x1234, 8),
+        make_word(0x10, 0xE8, 0x0001, 12),
+        make_word(0x32, 0x29, 0x1000, 16),
+        make_word(0x29, 0x10, RET_MASK, 20),
+        make_word(0x01, 0xF0, 0x0000, 24),
+        make_word(0x30, 0x00, 0x0002, 28),
+    ]
+
+    profiles = load_profiles(words)
+    tracker = StackTracker()
+    summary = tracker.run(profiles)
+
+    assert summary.change == -4
+    assert not summary.uncertain
+    assert all(not event.uncertain for event in summary.events)
+
+    call_dispatch = summary.events[2]
+    helper_call = summary.events[3]
+    tail_mask = summary.events[5]
+    teardown = summary.events[6]
+
+    assert call_dispatch.kind is InstructionKind.CALL
+    assert helper_call.kind is InstructionKind.CALL
+    assert tail_mask.kind is InstructionKind.TAILCALL
+    assert teardown.delta == -4
+
+
+def test_tail_mask_is_stack_neutral():
+    words = [make_word(0x29, 0x10, RET_MASK, 0)]
+
+    profiles = load_profiles(words)
+    tracker = StackTracker()
+    summary = tracker.run(profiles)
+
+    assert not summary.uncertain
+    assert len(summary.events) == 1
+    event = summary.events[0]
+    assert event.kind is InstructionKind.TAILCALL
+    assert event.delta == 0
+    assert not event.uncertain


### PR DESCRIPTION
## Summary
- teach the stack tracker to recognise call/tail wrapper opcodes, canonical shuffles and teardown helpers so their stack deltas become deterministic
- add unit coverage that exercises the call-helper cleanup wrapper and tail-mask dispatcher to ensure the stack model stays stable

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e421079c48832fa1e867061a01b1ec