### PR TITLE
Relax tail helper 0x0072 ASCII wrapper signature

### DIFF
--- a/knowledge/call_signatures.json
+++ b/knowledge/call_signatures.json
@@ -10,6 +10,45 @@
     "prelude": [
       {
         "kind": "raw",
+        "mnemonic": "op_03_00",
+        "operand": "0x3032",
+        "effect": {"mnemonic": "op_03_00", "operand": "0x3032"},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_4A_05",
+        "effect": {"mnemonic": "op_4A_05", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_00_52",
+        "effect": {"mnemonic": "op_00_52", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_4A_05",
+        "effect": {"mnemonic": "op_4A_05", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_03_00",
+        "operand": "0x3032",
+        "effect": {"mnemonic": "op_03_00", "operand": "0x3032"},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_66_1B",
+        "operand": "0x4B08",
+        "effect": {"mnemonic": "op_66_1B", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
         "mnemonic": "op_F0_4B",
         "operand": "0x4B08",
         "effect": {"mnemonic": "op_F0_4B", "operand": "0x4B08"}
@@ -28,6 +67,24 @@
       }
     ],
     "postlude": [
+      {
+        "kind": "raw",
+        "mnemonic": "op_52_05",
+        "effect": {"mnemonic": "op_52_05", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_32_29",
+        "effect": {"mnemonic": "op_32_29", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_52_05",
+        "effect": {"mnemonic": "op_52_05", "inherit_operand": true},
+        "optional": true
+      },
       {
         "kind": "raw",
         "mnemonic": "op_70_29",


### PR DESCRIPTION
## Summary
- broaden the 0x0072 call signature with optional prelude/postlude patterns so ASCII wrappers can be matched despite instruction permutations
- update the normalizer test fixtures and add coverage for the ASCII wrapper variant that exercises the relaxed signature

## Testing
- pytest tests/test_ir_normalizer.py

------
https://chatgpt.com/codex/tasks/task_e_68e42b259214832f859a39f536402335