### PR TITLE
Broaden tail helper 0x0072 call signature cleanup

### DIFF
--- a/knowledge/call_signatures.json
+++ b/knowledge/call_signatures.json
@@ -10,6 +10,16 @@
     "prelude": [
       {
         "kind": "raw",
+        "predicate": "literal_marker",
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "predicate": "literal_marker",
+        "optional": true
+      },
+      {
+        "kind": "raw",
         "mnemonic": "op_F0_4B",
         "operand": "0x4B08",
         "effect": {"mnemonic": "op_F0_4B", "operand": "0x4B08"}
@@ -32,6 +42,25 @@
         "kind": "raw",
         "mnemonic": "op_70_29",
         "effect": {"mnemonic": "op_70_29", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_52_05",
+        "effect": {"mnemonic": "op_52_05", "inherit_operand": true},
+        "optional": true
+      },
+      {
+        "kind": "raw",
+        "mnemonic": "op_32_29",
+        "effect": {"mnemonic": "op_32_29", "inherit_operand": true},
+        "cleanup_mask": "0x2910",
+        "optional": true
+      },
+      {
+        "kind": "cleanup",
+        "predicate": "ascii_epilogue",
+        "cleanup_mask": "0x2910",
         "optional": true
       },
       {

--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -145,8 +145,18 @@ def write_manual(path: Path) -> KnowledgeBase:
                 {"mnemonic": "stack_teardown", "pops": 1},
             ],
             "shuffle": "0x4B08",
-            "shuffle_options": ["0x4B08", "0x3032"],
+            "shuffle_options": ["0x4B08", "0x3032", "0x7223"],
             "prelude": [
+                {
+                    "kind": "raw",
+                    "predicate": "literal_marker",
+                    "optional": True,
+                },
+                {
+                    "kind": "raw",
+                    "predicate": "literal_marker",
+                    "optional": True,
+                },
                 {
                     "kind": "raw",
                     "mnemonic": "op_F0_4B",
@@ -173,6 +183,25 @@ def write_manual(path: Path) -> KnowledgeBase:
                     "effect": {"mnemonic": "op_70_29", "inherit_operand": True},
                     "optional": True,
                 },
+                {
+                    "kind": "raw",
+                    "mnemonic": "op_52_05",
+                    "effect": {"mnemonic": "op_52_05", "inherit_operand": True},
+                    "optional": True,
+                },
+                {
+                    "kind": "raw",
+                    "mnemonic": "op_32_29",
+                    "effect": {"mnemonic": "op_32_29", "inherit_operand": True},
+                    "cleanup_mask": "0x2910",
+                    "optional": True,
+                },
+                {
+                    "kind": "cleanup",
+                    "predicate": "ascii_epilogue",
+                    "cleanup_mask": "0x2910",
+                    "optional": True,
+                },
             ],
         }
     }
@@ -192,8 +221,10 @@ def build_container(tmp_path: Path) -> tuple[MbcContainer, KnowledgeBase]:
         build_word(20, 0x2B, 0x00, 0x0072),
         build_word(24, 0x29, 0x10, 0x2910),
         build_word(28, 0x70, 0x29, 0x0001),
-        build_word(32, 0x27, 0x00, 0x0008),
-        build_word(36, 0x30, 0x00, 0x0001),
+        build_word(32, 0x52, 0x05, 0x0000),
+        build_word(36, 0x32, 0x29, 0x2910),
+        build_word(40, 0x27, 0x00, 0x0008),
+        build_word(44, 0x30, 0x00, 0x0001),
     ]
     seg1_words = [
         build_word(0, 0x00, 0x00, 0x0003),
@@ -363,6 +394,8 @@ def test_normalizer_builds_ir(tmp_path: Path) -> None:
         "op_5E_29",
         "op_F0_4B",
         "stack_teardown",
+        "op_52_05",
+        "op_32_29",
     ]
 
     if_nodes = [


### PR DESCRIPTION
## Summary
- extend the 0x0072 call signature so the prelude tolerates literal markers and the postlude absorbs the ASCII epilogue helper pair
- teach the IR normalizer to match literal-marker predicates, IRCallCleanup nodes, and skip mask instructions when assembling call contracts
- expand the normalizer tests to cover the richer signature and assert the additional cleanup effects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e43d307d24832f91751dea6ad8a242