### PR TITLE
Normalize testset branches and expand ASCII signatures

### DIFF
--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -154,7 +154,7 @@ class AsciiRunSignature(SignatureRule):
 class HeaderAsciiCtrlSeqSignature(SignatureRule):
     """Match ASCII headers that transition into control sequences."""
 
-    name = "header_ascii_ctrl_seq"
+    name = "ascii_header"
     category = "literal"
     base_confidence = 0.6
     _ctrl_labels = {"34:2E", "33:FF", "EB:0B", "C9:29"}
@@ -298,7 +298,7 @@ class LiteralRunWithMarkersSignature(SignatureRule):
 class ReduceAsciiPrologSignature(SignatureRule):
     """Recognise the ``reduce`` + ``00:4F`` marker that precedes ASCII payloads."""
 
-    name = "reduce_ascii_prolog"
+    name = "ascii_inline"
     category = "literal"
     base_confidence = 0.6
 
@@ -331,7 +331,7 @@ class ReduceAsciiPrologSignature(SignatureRule):
 class MarkerPairWithHeaderSignature(SignatureRule):
     """Detect paired literal markers that introduce a fixed header sequence."""
 
-    name = "marker_pair_with_header"
+    name = "ascii_marker"
     category = "literal"
     base_confidence = 0.6
 
@@ -376,7 +376,7 @@ class MarkerPairWithHeaderSignature(SignatureRule):
 class AsciiPrologMarkerComboSignature(SignatureRule):
     """Recognise ASCII literals wrapped by a ``05:00`` prolog and marker pair."""
 
-    name = "ascii_prolog_marker_combo"
+    name = "ascii_marker_combo"
     category = "literal"
     base_confidence = 0.59
 
@@ -434,7 +434,7 @@ class AsciiPrologMarkerComboSignature(SignatureRule):
 class AsciiWrapperEf48Signature(SignatureRule):
     """Match ASCII payloads wrapped by ``EF:28`` and ``48:00`` sentinels."""
 
-    name = "ascii_wrapper_ef48"
+    name = "ascii_wrapper"
     category = "literal"
     base_confidence = 0.6
 
@@ -479,7 +479,7 @@ class AsciiWrapperEf48Signature(SignatureRule):
 class AsciiReduceMarkerSignature(SignatureRule):
     """Detect ASCII or reduction prologs that end with ``66:1B`` → markers."""
 
-    name = "ascii_reduce_marker_seq"
+    name = "ascii_block"
     category = "literal"
     base_confidence = 0.58
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -226,7 +226,7 @@ def test_signature_detector_matches_indirect_return_ex():
     assert match.name == "indirect_return_ex"
 
 
-def test_signature_detector_matches_header_ascii_ctrl_seq():
+def test_signature_detector_matches_ascii_header():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [
         InstructionWord(0, int.from_bytes(b"scpt", "big")),
@@ -239,7 +239,7 @@ def test_signature_detector_matches_header_ascii_ctrl_seq():
     detector = SignatureDetector()
     match = detector.detect(profiles, summary)
     assert match is not None
-    assert match.name == "header_ascii_ctrl_seq"
+    assert match.name == "ascii_header"
 
 
 def test_signature_detector_matches_ascii_control_cluster():
@@ -291,7 +291,7 @@ def test_signature_detector_matches_literal_run_with_markers():
     assert match.name == "literal_run_with_markers"
 
 
-def test_signature_detector_matches_ascii_reduce_marker_seq():
+def test_signature_detector_matches_ascii_block():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [
         make_word(0x04, 0x00, 0x0000, 0),
@@ -305,10 +305,10 @@ def test_signature_detector_matches_ascii_reduce_marker_seq():
     detector = SignatureDetector()
     match = detector.detect(profiles, summary)
     assert match is not None
-    assert match.name == "ascii_reduce_marker_seq"
+    assert match.name == "ascii_block"
 
 
-def test_signature_detector_matches_reduce_ascii_prolog():
+def test_signature_detector_matches_ascii_inline():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [
         make_word(0x04, 0x00, 0x0000, 0),
@@ -320,7 +320,7 @@ def test_signature_detector_matches_reduce_ascii_prolog():
     detector = SignatureDetector()
     match = detector.detect(profiles, summary)
     assert match is not None
-    assert match.name == "reduce_ascii_prolog"
+    assert match.name == "ascii_inline"
 
 
 def test_signature_detector_matches_literal_zero_init():
@@ -339,7 +339,7 @@ def test_signature_detector_matches_literal_zero_init():
     assert match.name == "literal_zero_init"
 
 
-def test_signature_detector_matches_marker_pair_with_header():
+def test_signature_detector_matches_ascii_marker():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [
         make_word(0x40, 0x00, 0x0000, 0),
@@ -351,7 +351,7 @@ def test_signature_detector_matches_marker_pair_with_header():
     detector = SignatureDetector()
     match = detector.detect(profiles, summary)
     assert match is not None
-    assert match.name == "marker_pair_with_header"
+    assert match.name == "ascii_marker"
 
 
 def test_signature_detector_matches_marker_fence_reduce():
@@ -371,7 +371,7 @@ def test_signature_detector_matches_marker_fence_reduce():
     assert match.name == "marker_fence_reduce"
 
 
-def test_signature_detector_matches_ascii_prolog_marker_combo():
+def test_signature_detector_matches_ascii_marker_combo():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [
         make_word(0x05, 0x00, 0x0000, 0),
@@ -384,10 +384,10 @@ def test_signature_detector_matches_ascii_prolog_marker_combo():
     detector = SignatureDetector()
     match = detector.detect(profiles, summary)
     assert match is not None
-    assert match.name == "ascii_prolog_marker_combo"
+    assert match.name == "ascii_marker_combo"
 
 
-def test_signature_detector_matches_ascii_wrapper_ef48():
+def test_signature_detector_matches_ascii_wrapper():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [
         make_word(0xEF, 0x28, 0x0000, 0),
@@ -399,7 +399,7 @@ def test_signature_detector_matches_ascii_wrapper_ef48():
     detector = SignatureDetector()
     match = detector.detect(profiles, summary)
     assert match is not None
-    assert match.name == "ascii_wrapper_ef48"
+    assert match.name == "ascii_wrapper"
 
 
 def test_signature_detector_matches_ascii_tailcall_pattern():


### PR DESCRIPTION
## Summary
- add a dedicated normalization pass for testset_branch instructions and keep SSA information when folding prologues
- collapse reduce_pair sequences that glue constant aggregates, broaden call preparation/cleanup semantics, and mark additional helpers
- rename ASCII-related signatures to the new ascii_* naming scheme and extend tests for the updated normalizer behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e45b9a1ca4832f9549248652e5a02d