### PR TITLE
Collapse opcode table instruction runs

### DIFF
--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -699,7 +699,7 @@ class ModeSweepSignature(SignatureRule):
             return None
 
         (mode,) = modes
-        if mode not in {0x4E, 0x4F}:
+        if mode not in {0x2A, 0x2B, 0x32, 0x33, 0x46, 0x47, 0x4E, 0x4F}:
             return None
 
         distinct_opcodes = {profile.opcode for profile in profiles}

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -383,6 +383,7 @@ class IRLiteralBlock(IRNode):
     reducer: Optional[str] = None
     reducer_operand: Optional[int] = None
     tail: Tuple[int, ...] = tuple()
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
         chunks = []
@@ -397,6 +398,8 @@ class IRLiteralBlock(IRNode):
                 f" 0x{self.reducer_operand:04X}" if self.reducer_operand is not None else ""
             )
             base += f" via {self.reducer}{operand}"
+        if self.annotations:
+            base += " " + ", ".join(self.annotations)
         return base
 
 
@@ -643,9 +646,12 @@ class IRTablePatch(IRNode):
     """Collapses the recurring 0x66xx table patch sequences."""
 
     operations: Tuple[Tuple[str, int], ...]
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
         rendered = ", ".join(f"{mnemonic}(0x{operand:04X})" for mnemonic, operand in self.operations)
+        if self.annotations:
+            rendered += " " + ", ".join(self.annotations)
         return f"table_patch[{rendered}]"
 
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -137,6 +137,21 @@ def test_signature_detector_matches_mode_sweep_block():
     assert match.name == "mode_sweep_block"
 
 
+def test_signature_detector_matches_extended_mode_sweep_block():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    words = [
+        make_word(0x80, 0x2A, 0x0001, 0),
+        make_word(0x81, 0x2A, 0x0002, 4),
+        make_word(0x82, 0x2A, 0x0003, 8),
+        make_word(0x83, 0x2A, 0x0004, 12),
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "mode_sweep_block"
+
+
 def test_signature_detector_matches_stack_lift_pair():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [


### PR DESCRIPTION
## Summary
- collapse long opcode table ribbons into annotated IRTablePatch nodes and mark neighbouring literal chunks
- allow literal/table IR nodes to carry opcode_table annotations for downstream passes
- extend the mode sweep signature coverage and add regression tests for the new normaliser behaviour

## Testing
- pytest tests/test_ir_normalizer.py::test_normalizer_collapses_opcode_table_runs tests/test_ir_normalizer.py::test_opcode_table_literals_are_tagged tests/test_signatures.py::test_signature_detector_matches_extended_mode_sweep_block

------
https://chatgpt.com/codex/tasks/task_e_68e58a750254832faaf50b2c1b1b478c