### PR TITLE
Collapse opcode table runs in normalizer

### DIFF
--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -383,6 +383,7 @@ class IRLiteralBlock(IRNode):
     reducer: Optional[str] = None
     reducer_operand: Optional[int] = None
     tail: Tuple[int, ...] = tuple()
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
         chunks = []
@@ -397,6 +398,8 @@ class IRLiteralBlock(IRNode):
                 f" 0x{self.reducer_operand:04X}" if self.reducer_operand is not None else ""
             )
             base += f" via {self.reducer}{operand}"
+        if self.annotations:
+            base += " " + ", ".join(self.annotations)
         return base
 
 
@@ -643,10 +646,14 @@ class IRTablePatch(IRNode):
     """Collapses the recurring 0x66xx table patch sequences."""
 
     operations: Tuple[Tuple[str, int], ...]
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
         rendered = ", ".join(f"{mnemonic}(0x{operand:04X})" for mnemonic, operand in self.operations)
-        return f"table_patch[{rendered}]"
+        base = f"table_patch[{rendered}]"
+        if self.annotations:
+            base += " " + ", ".join(self.annotations)
+        return base
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- add a normalizer pass that collapses long runs of opcode-table instructions into IRTablePatch nodes tagged as opcode tables
- extend IRTablePatch and IRLiteralBlock to carry optional annotations for tagging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58a750254832faaf50b2c1b1b478c