### PR TITLE
Collapse opcode table runs into structured nodes

### DIFF
--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -699,7 +699,8 @@ class ModeSweepSignature(SignatureRule):
             return None
 
         (mode,) = modes
-        if mode not in {0x4E, 0x4F}:
+        allowed_modes = {0x2A, 0x2B, 0x32, 0x33, 0x46, 0x47, 0x4E, 0x4F}
+        if mode not in allowed_modes:
             return None
 
         distinct_opcodes = {profile.opcode for profile in profiles}

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -383,6 +383,7 @@ class IRLiteralBlock(IRNode):
     reducer: Optional[str] = None
     reducer_operand: Optional[int] = None
     tail: Tuple[int, ...] = tuple()
+    tag: Optional[str] = None
 
     def describe(self) -> str:
         chunks = []
@@ -397,6 +398,8 @@ class IRLiteralBlock(IRNode):
                 f" 0x{self.reducer_operand:04X}" if self.reducer_operand is not None else ""
             )
             base += f" via {self.reducer}{operand}"
+        if self.tag:
+            base = f"{self.tag} {base}"
         return base
 
 
@@ -643,10 +646,12 @@ class IRTablePatch(IRNode):
     """Collapses the recurring 0x66xx table patch sequences."""
 
     operations: Tuple[Tuple[str, int], ...]
+    tag: Optional[str] = None
 
     def describe(self) -> str:
         rendered = ", ".join(f"{mnemonic}(0x{operand:04X})" for mnemonic, operand in self.operations)
-        return f"table_patch[{rendered}]"
+        prefix = f"{self.tag} " if self.tag else ""
+        return f"{prefix}table_patch[{rendered}]"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- collapse long runs of opcode-only instructions into tagged IRTablePatch nodes during normalisation
- allow literal and table IR nodes to carry an opcode_table tag and widen the mode sweep signature coverage
- cover the new opcode table collapsing logic with dedicated normaliser tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58a750254832faaf50b2c1b1b478c