### PR TITLE
Normalize opcode table instruction runs

### DIFF
--- a/mbcdisasm/analyzer/signatures.py
+++ b/mbcdisasm/analyzer/signatures.py
@@ -699,7 +699,8 @@ class ModeSweepSignature(SignatureRule):
             return None
 
         (mode,) = modes
-        if mode not in {0x4E, 0x4F}:
+        accepted = {0x2A, 0x2B, 0x32, 0x33, 0x46, 0x47, 0x48, 0x4E, 0x4F, 0x50, 0x51}
+        if mode not in accepted:
             return None
 
         distinct_opcodes = {profile.opcode for profile in profiles}

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -383,6 +383,7 @@ class IRLiteralBlock(IRNode):
     reducer: Optional[str] = None
     reducer_operand: Optional[int] = None
     tail: Tuple[int, ...] = tuple()
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
         chunks = []
@@ -397,6 +398,8 @@ class IRLiteralBlock(IRNode):
                 f" 0x{self.reducer_operand:04X}" if self.reducer_operand is not None else ""
             )
             base += f" via {self.reducer}{operand}"
+        if self.annotations:
+            base += " " + ", ".join(self.annotations)
         return base
 
 
@@ -643,10 +646,14 @@ class IRTablePatch(IRNode):
     """Collapses the recurring 0x66xx table patch sequences."""
 
     operations: Tuple[Tuple[str, int], ...]
+    annotations: Tuple[str, ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
         rendered = ", ".join(f"{mnemonic}(0x{operand:04X})" for mnemonic, operand in self.operations)
-        return f"table_patch[{rendered}]"
+        description = f"table_patch[{rendered}]"
+        if self.annotations:
+            description += " " + ", ".join(self.annotations)
+        return description
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- collapse long runs of opcode-table instructions into annotated IRTablePatch nodes and allow literal or cleanup spacers to survive aggregation
- extend the mode sweep heuristic to cover the additional decoder modes that now normalize into structured tables
- let IR table nodes carry annotations and add a regression test for the opcode table pass

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5921b72fc832f81beba91caac8d23