### PR TITLE
Improve ASCII mixed detection and normalization

### DIFF
--- a/mbcdisasm/analyzer/instruction_profile.py
+++ b/mbcdisasm/analyzer/instruction_profile.py
@@ -471,6 +471,25 @@ def looks_like_ascii_chunk(word: InstructionWord) -> bool:
     return printable > 0
 
 
+def is_ascii_mixed_word(word: InstructionWord) -> bool:
+    """Return ``True`` when ``word`` mostly consists of printable ASCII bytes."""
+
+    data = word.raw.to_bytes(4, "big")
+    printable = 0
+
+    for byte in data:
+        if 0x20 <= byte <= 0x7E:
+            printable += 1
+            continue
+        if byte <= 0x0F:
+            continue
+        if byte < 0x20:
+            return False
+        return False
+
+    return printable >= 3
+
+
 def heuristic_stack_adjustment(profile: InstructionProfile) -> Optional[int]:
     """Return additional stack delta adjustments derived from heuristics."""
 

--- a/mbcdisasm/ir/model.py
+++ b/mbcdisasm/ir/model.py
@@ -735,9 +735,20 @@ class IRAsciiHeader(IRNode):
     """Captures dense ASCII banners embedded at block boundaries."""
 
     chunks: Tuple[str, ...]
+    chunk_annotations: Tuple[Tuple[str, ...], ...] = field(default_factory=tuple)
 
     def describe(self) -> str:
-        rendered = ", ".join(self.chunks)
+        if self.chunk_annotations and len(self.chunk_annotations) == len(self.chunks):
+            parts: List[str] = []
+            for name, annotations in zip(self.chunks, self.chunk_annotations):
+                if annotations:
+                    rendered_annotations = ", ".join(annotations)
+                    parts.append(f"{name} ({rendered_annotations})")
+                else:
+                    parts.append(name)
+            rendered = ", ".join(parts)
+        else:
+            rendered = ", ".join(self.chunks)
         return f"ascii_header[{rendered}]"
 
 

--- a/tests/test_ir_normalizer.py
+++ b/tests/test_ir_normalizer.py
@@ -36,7 +36,7 @@ from mbcdisasm.mbc import Segment
 from mbcdisasm.instruction import InstructionWord
 from mbcdisasm.knowledge import KnowledgeBase, OpcodeInfo
 from mbcdisasm.analyzer.instruction_profile import InstructionProfile
-from mbcdisasm.analyzer.stack import StackTracker
+from mbcdisasm.analyzer.stack import StackEvent, StackTracker
 
 
 def build_word(offset: int, opcode: int, mode: int, operand: int) -> InstructionWord:
@@ -550,6 +550,73 @@ def test_normalizer_collapses_ascii_runs_and_literal_hints(tmp_path: Path) -> No
     assert constant.data == b"A\x00B\x00\x00C\x00D"
     assert constant.segments == (constant.data,)
     assert "lit(0x6704)" in descriptions
+
+
+def test_normalizer_merges_ascii_mixed_chunks(tmp_path: Path) -> None:
+    knowledge = write_manual(tmp_path)
+    words = [
+        InstructionWord(0, int.from_bytes(b"text", "big")),
+        InstructionWord(4, int.from_bytes(b"\x01abc", "big")),
+        InstructionWord(8, int.from_bytes(b"tail", "big")),
+    ]
+
+    data = encode_instructions(words)
+    descriptor = SegmentDescriptor(0, 0, len(data))
+    segment = Segment(descriptor, data)
+    container = MbcContainer(Path("dummy"), [segment])
+
+    normalizer = IRNormalizer(knowledge)
+    program = normalizer.normalise_container(container)
+    block = program.segments[0].blocks[0]
+
+    header = next(node for node in block.nodes if isinstance(node, IRAsciiHeader))
+    pool = {const.name: const for const in program.string_pool}
+    assert header.chunks and len(header.chunks) == 1
+    symbol = header.chunks[0]
+    assert symbol in pool
+    assert pool[symbol].data == b"text\x01abctail"
+
+
+def test_ascii_mixed_pass_converts_adjacent_raw(tmp_path: Path) -> None:
+    knowledge = write_manual(tmp_path)
+    normalizer = IRNormalizer(knowledge)
+
+    def build_raw(word_bytes: bytes) -> RawInstruction:
+        word = InstructionWord(0, int.from_bytes(word_bytes, "big"))
+        profile = InstructionProfile.from_word(word, knowledge)
+        event = StackEvent(
+            profile=profile,
+            delta=0,
+            minimum=0,
+            maximum=0,
+            confidence=1.0,
+            depth_before=0,
+            depth_after=0,
+            kind=profile.kind,
+        )
+        return RawInstruction(
+            profile=profile,
+            event=event,
+            annotations=tuple(),
+            ssa_values=tuple(),
+            ssa_kinds=tuple(),
+        )
+
+    left_chunk = normalizer._literal_from_instruction(build_raw(b"text"))
+    assert isinstance(left_chunk, IRLiteralChunk)
+    right_chunk = normalizer._literal_from_instruction(build_raw(b"tail"))
+    assert isinstance(right_chunk, IRLiteralChunk)
+
+    mixed_instruction = build_raw(b"\x01abc")
+
+    items = _ItemList([left_chunk, mixed_instruction, right_chunk])
+    metrics = NormalizerMetrics()
+    normalizer._pass_ascii_mixed(items, metrics)
+
+    assert isinstance(items[1], IRLiteralChunk)
+    assert items[1].data == b"\x01abc"
+    assert "ascii_mixed" in items[1].annotations
+    assert metrics.literal_chunks == 1
 
 
 def test_normalizer_glues_ascii_reduce_chains(tmp_path: Path) -> None:

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -60,6 +60,20 @@ def test_signature_detector_matches_ascii_run():
     assert match.category == "literal"
 
 
+def test_signature_detector_matches_ascii_run_with_mixed_chunks():
+    knowledge = KnowledgeBase({})
+    words = [
+        InstructionWord(0, int.from_bytes(b"text", "big")),
+        InstructionWord(4, int.from_bytes(b"\x01abc", "big")),
+        InstructionWord(8, int.from_bytes(b"more", "big")),
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "ascii_run"
+
+
 def test_signature_detector_matches_literal_run():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [make_word(0x00, 0x00, operand, idx * 4) for idx, operand in enumerate([0x10, 0x11, 0x12, 0x13, 0x14])]
@@ -318,6 +332,21 @@ def test_signature_detector_matches_ascii_inline():
         make_word(0x00, 0x4F, 0x0110, 4),
         InstructionWord(8, int.from_bytes(b"text", "big")),
         InstructionWord(12, int.from_bytes(b"DATA", "big")),
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "ascii_inline"
+
+
+def test_signature_detector_matches_ascii_inline_with_mixed_chunk():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    words = [
+        make_word(0x04, 0x00, 0x0000, 0),
+        make_word(0x00, 0x4F, 0x0110, 4),
+        InstructionWord(8, int.from_bytes(b"\x01abc", "big")),
+        InstructionWord(12, int.from_bytes(b"text", "big")),
     ]
     profiles, summary = profiles_from_words(words, knowledge)
     detector = SignatureDetector()


### PR DESCRIPTION
## Summary
- add an `is_ascii_mixed_word` helper and expand ASCII signatures to tolerate occasional control bytes
- introduce an ASCII mixed pass in the IR normalizer so mixed words are folded into literal runs
- exercise the new behaviour with dedicated signature and normalizer tests

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e5a97db790832faae5e809b9310f1b