### PR TITLE
Improve ASCII chunk fusion and canonicalization

### DIFF
--- a/mbcdisasm/analyzer/instruction_profile.py
+++ b/mbcdisasm/analyzer/instruction_profile.py
@@ -471,6 +471,25 @@ def looks_like_ascii_chunk(word: InstructionWord) -> bool:
     return printable > 0
 
 
+def is_ascii_mixed_word(word: InstructionWord) -> bool:
+    """Return ``True`` when ``word`` mostly consists of printable ASCII bytes."""
+
+    data = word.raw.to_bytes(4, "big")
+    printable = 0
+
+    for byte in data:
+        if 0x20 <= byte <= 0x7E:
+            printable += 1
+            continue
+        if byte <= 0x0F:
+            continue
+        if byte < 0x20:
+            return False
+        return False
+
+    return printable >= 3
+
+
 def heuristic_stack_adjustment(profile: InstructionProfile) -> Optional[int]:
     """Return additional stack delta adjustments derived from heuristics."""
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -60,6 +60,20 @@ def test_signature_detector_matches_ascii_run():
     assert match.category == "literal"
 
 
+def test_signature_detector_matches_ascii_run_with_mixed_chunks():
+    knowledge = KnowledgeBase({})
+    words = [
+        InstructionWord(0, int.from_bytes(b"text", "big")),
+        InstructionWord(4, int.from_bytes(b"\x01abc", "big")),
+        InstructionWord(8, int.from_bytes(b"more", "big")),
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "ascii_run"
+
+
 def test_signature_detector_matches_literal_run():
     knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
     words = [make_word(0x00, 0x00, operand, idx * 4) for idx, operand in enumerate([0x10, 0x11, 0x12, 0x13, 0x14])]
@@ -318,6 +332,21 @@ def test_signature_detector_matches_ascii_inline():
         make_word(0x00, 0x4F, 0x0110, 4),
         InstructionWord(8, int.from_bytes(b"text", "big")),
         InstructionWord(12, int.from_bytes(b"DATA", "big")),
+    ]
+    profiles, summary = profiles_from_words(words, knowledge)
+    detector = SignatureDetector()
+    match = detector.detect(profiles, summary)
+    assert match is not None
+    assert match.name == "ascii_inline"
+
+
+def test_signature_detector_matches_ascii_inline_with_mixed_chunk():
+    knowledge = KnowledgeBase.load(Path("knowledge/manual_annotations.json"))
+    words = [
+        make_word(0x04, 0x00, 0x0000, 0),
+        make_word(0x00, 0x4F, 0x0110, 4),
+        InstructionWord(8, int.from_bytes(b"\x01abc", "big")),
+        InstructionWord(12, int.from_bytes(b"text", "big")),
     ]
     profiles, summary = profiles_from_words(words, knowledge)
     detector = SignatureDetector()


### PR DESCRIPTION
## Summary
- track literal spans and raw payloads so mixed ASCII words can be merged and reassembled reliably
- add a late ascii_stitch pass plus span-aware run/glue reducers to join contiguous ASCII nodes while tolerating small null gaps
- canonicalise leading and trailing null padding when interning string constants and cover the behaviour with dedicated tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5a97db790832faae5e809b9310f1b