### PR TITLE
Expand IO normalization to cover direct port sequences

### DIFF
--- a/mbcdisasm/constants.py
+++ b/mbcdisasm/constants.py
@@ -14,6 +14,7 @@ from typing import Dict
 RET_MASK = 0x2910
 IO_SLOT = 0x6910
 IO_PORT_NAME = "io.port_6910"
+IO_DIRECT_PORT_NAME = "io.port_3D30"
 PAGE_REGISTER = 0x6C01
 FANOUT_FLAGS_A = 0x2C02
 FANOUT_FLAGS_B = 0x2C03
@@ -53,6 +54,7 @@ __all__ = [
     "RET_MASK",
     "IO_SLOT",
     "IO_PORT_NAME",
+    "IO_DIRECT_PORT_NAME",
     "PAGE_REGISTER",
     "FANOUT_FLAGS_A",
     "FANOUT_FLAGS_B",


### PR DESCRIPTION
## Summary
- expand the IO normalizer to recognise more read/write mnemonics, treat new bridge opcodes as transparent, and emit nodes for direct writes to port 0x3D30
- stop ASCII chunk folding from consuming direct IO opcodes and allow handshake discovery in both directions so wrappers around the port collapse into IO nodes
- add regression tests that cover the new IO patterns and ensure direct-port access renders correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b8f37c88832f964bc5bc4544ddcc