### PR TITLE
Add AST reconstruction phase with dominator analysis

### DIFF
--- a/mbc_disasm.py
+++ b/mbc_disasm.py
@@ -14,6 +14,8 @@ from mbcdisasm import (
     IRTextRenderer,
     KnowledgeBase,
     MbcContainer,
+    ASTBuilder,
+    ASTRenderer
 )
 
 
@@ -105,6 +107,13 @@ def main() -> None:
     ir_output_path = args.ir_out or mbc_path.with_suffix(".ir.txt")
     IRTextRenderer().write(program, ir_output_path)
     print(f"ir written to {ir_output_path}")
+    
+    ast_program = ASTBuilder().build(program)
+    ast_text = ASTRenderer().render(ast_program)
+    ast_output_path = args.ast_out or mbc_path.with_suffix(".ast.txt")
+    with ast_output_path.open("w", encoding="utf-8") as f:
+        f.write(ast_text)
+    print(f"ast written to {ast_output_path}")
 
     total_time = time.perf_counter() - start_time
     print(f"total execution time: {total_time:.2f}s")

--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -4,6 +4,7 @@ from .adb import SegmentDescriptor, SegmentIndex
 from .disassembler import Disassembler
 from .instruction import InstructionWord
 from .ir import IRNormalizer, IRTextRenderer
+from .ast import ASTBuilder, ASTRenderer
 from .knowledge import KnowledgeBase
 from .mbc import MbcContainer, Segment
 
@@ -16,5 +17,7 @@ __all__ = [
     "MbcContainer",
     "Segment",
     "IRNormalizer",
-    "IRTextRenderer"
+    "IRTextRenderer",
+    "ASTBuilder",
+    "ASTRenderer",
 ]

--- a/mbcdisasm/ast/__init__.py
+++ b/mbcdisasm/ast/__init__.py
@@ -1,0 +1,17 @@
+"""Public exports for the AST reconstruction stage."""
+
+from .builder import ASTBuilder
+from .model import ASTBlock, ASTFunction, ASTLoop, ASTProgram, ASTTerminator, DominatorInfo
+from .renderer import ASTRenderer
+
+__all__ = [
+    "ASTBuilder",
+    "ASTRenderer",
+    "ASTProgram",
+    "ASTFunction",
+    "ASTBlock",
+    "ASTLoop",
+    "ASTTerminator",
+    "DominatorInfo",
+]
+

--- a/mbcdisasm/ast/builder.py
+++ b/mbcdisasm/ast/builder.py
@@ -1,0 +1,646 @@
+"""Construction of the high level AST from the normalised IR."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple
+
+from ..ir.model import (
+    IRBlock,
+    IRCallReturn,
+    IRFunctionCfg,
+    IRIf,
+    IRReturn,
+    IRSegment,
+    IRSwitchDispatch,
+    IRTestSetBranch,
+    IRFlagCheck,
+    IRFunctionPrologue,
+    IRTailCall,
+    IRTailcallReturn,
+    IRTerminator,
+    IRProgram,
+    IRNode,
+)
+from ..ir.cfg import analyse_segments
+from .model import ASTBlock, ASTFunction, ASTLoop, ASTProgram, ASTTerminator, DominatorInfo
+
+
+@dataclass
+class _Edge:
+    kind: str
+    target: str
+
+
+@dataclass
+class _GotoTerminator:
+    target: str
+
+
+@dataclass
+class _MutableBlock:
+    label: str
+    start_offset: int
+    statements: List[IRNode]
+    terminator: Optional[object]
+    edges: List[_Edge]
+    predecessors: Set[str]
+    synthetic: bool = False
+
+
+_TERMINATOR_TYPES = (
+    IRReturn,
+    IRTailCall,
+    IRTailcallReturn,
+    IRCallReturn,
+    IRIf,
+    IRTestSetBranch,
+    IRFlagCheck,
+    IRFunctionPrologue,
+    IRSwitchDispatch,
+    IRTerminator,
+)
+
+
+class ASTBuilder:
+    """Build an :class:`ASTProgram` from a normalised :class:`IRProgram`."""
+
+    def build(self, program: IRProgram) -> ASTProgram:
+        if program.cfg is None:
+            cfg, _ = analyse_segments(program.segments)
+        else:
+            cfg = program.cfg
+
+        block_lookup = self._build_block_lookup(program.segments)
+        functions: List[ASTFunction] = []
+
+        for function_cfg in cfg.functions:
+            ast_function = self._build_function(function_cfg, block_lookup)
+            functions.append(ast_function)
+
+        return ASTProgram(functions=tuple(functions))
+
+    # ------------------------------------------------------------------
+    # construction helpers
+    # ------------------------------------------------------------------
+    def _build_block_lookup(self, segments: Sequence[IRSegment]) -> Mapping[str, IRBlock]:
+        lookup: Dict[str, IRBlock] = {}
+        for segment in segments:
+            for block in segment.blocks:
+                lookup[block.label] = block
+        return lookup
+
+    def _build_function(
+        self,
+        function_cfg: IRFunctionCfg,
+        block_lookup: Mapping[str, IRBlock],
+    ) -> ASTFunction:
+        blocks = self._initialise_blocks(function_cfg, block_lookup)
+        if function_cfg.entry_block not in blocks:
+            raise ValueError(f"entry block {function_cfg.entry_block} missing from CFG")
+
+        self._prune_unreachable(function_cfg.entry_block, blocks)
+        self._merge_degenerate_blocks(function_cfg.entry_block, blocks)
+        self._remove_critical_edges(blocks)
+        self._fold_redundant_branches(blocks)
+        self._prune_unreachable(function_cfg.entry_block, blocks)
+
+        dominators = self._compute_dominator_info(function_cfg.entry_block, blocks)
+        post_dominators = self._compute_post_dominator_info(
+            function_cfg.entry_block, blocks
+        )
+        loops = self._identify_loops(dominators, blocks)
+
+        ast_blocks = self._freeze_blocks(blocks)
+
+        return ASTFunction(
+            segment_index=function_cfg.segment_index,
+            name=function_cfg.name,
+            entry_block=function_cfg.entry_block,
+            entry_offset=function_cfg.entry_offset,
+            blocks=ast_blocks,
+            dominators=dominators,
+            post_dominators=post_dominators,
+            loops=loops,
+        )
+
+    def _initialise_blocks(
+        self,
+        function_cfg: IRFunctionCfg,
+        block_lookup: Mapping[str, IRBlock],
+    ) -> MutableMapping[str, _MutableBlock]:
+        blocks: Dict[str, _MutableBlock] = {}
+        for cfg_block in function_cfg.blocks:
+            ir_block = block_lookup.get(cfg_block.label)
+            if ir_block is None:
+                raise ValueError(f"missing IR block for label {cfg_block.label}")
+            statements, terminator = self._split_block(ir_block)
+            edges = [_Edge(edge.kind, edge.target) for edge in cfg_block.edges]
+            blocks[cfg_block.label] = _MutableBlock(
+                label=cfg_block.label,
+                start_offset=cfg_block.start_offset,
+                statements=statements,
+                terminator=terminator,
+                edges=edges,
+                predecessors=set(),
+                synthetic=False,
+            )
+        for block in blocks.values():
+            for edge in block.edges:
+                target = blocks.get(edge.target)
+                if target is not None:
+                    target.predecessors.add(block.label)
+        return blocks
+
+    def _split_block(self, block: IRBlock) -> Tuple[List[IRNode], Optional[IRNode]]:
+        if not block.nodes:
+            return [], None
+        statements = list(block.nodes)
+        terminator: Optional[IRNode] = None
+        for index in range(len(statements) - 1, -1, -1):
+            node = statements[index]
+            if isinstance(node, _TERMINATOR_TYPES):
+                terminator = node
+                del statements[index]
+                break
+        return statements, terminator
+
+    # ------------------------------------------------------------------
+    # graph normalisation passes
+    # ------------------------------------------------------------------
+    def _prune_unreachable(
+        self, entry: str, blocks: MutableMapping[str, _MutableBlock]
+    ) -> None:
+        reachable = set(self._dfs(entry, blocks))
+        removed = True
+        while removed:
+            removed = False
+            for label in list(blocks.keys()):
+                if label not in reachable:
+                    self._delete_block(label, blocks)
+                    removed = True
+            if removed:
+                reachable = set(self._dfs(entry, blocks))
+
+    def _dfs(self, start: str, blocks: Mapping[str, _MutableBlock]) -> Iterable[str]:
+        if start not in blocks:
+            return []
+        visited: Set[str] = set()
+        order: List[str] = []
+        stack = [start]
+        while stack:
+            label = stack.pop()
+            if label in visited:
+                continue
+            visited.add(label)
+            order.append(label)
+            block = blocks[label]
+            for edge in reversed(block.edges):
+                if edge.target in blocks:
+                    stack.append(edge.target)
+        return order
+
+    def _delete_block(
+        self, label: str, blocks: MutableMapping[str, _MutableBlock]
+    ) -> None:
+        block = blocks.pop(label, None)
+        if block is None:
+            return
+        for predecessor_label in list(block.predecessors):
+            predecessor = blocks.get(predecessor_label)
+            if predecessor is None:
+                continue
+            predecessor.edges = [
+                edge for edge in predecessor.edges if edge.target != label
+            ]
+        for edge in block.edges:
+            successor = blocks.get(edge.target)
+            if successor is None:
+                continue
+            successor.predecessors.discard(label)
+
+    def _merge_degenerate_blocks(
+        self, entry: str, blocks: MutableMapping[str, _MutableBlock]
+    ) -> None:
+        changed = True
+        while changed:
+            changed = False
+            for label, block in list(blocks.items()):
+                if label == entry:
+                    continue
+                if block.synthetic:
+                    continue
+                if block.statements:
+                    continue
+                if len(block.edges) != 1:
+                    continue
+                target_label = block.edges[0].target
+                if target_label == label:
+                    continue
+                target = blocks.get(target_label)
+                if target is None:
+                    continue
+                if isinstance(block.terminator, (IRIf, IRTestSetBranch, IRFlagCheck, IRFunctionPrologue, IRSwitchDispatch)):
+                    continue
+                # rewrite predecessors to jump directly to the successor
+                for predecessor_label in list(block.predecessors):
+                    predecessor = blocks.get(predecessor_label)
+                    if predecessor is None:
+                        continue
+                    updated = False
+                    for edge in predecessor.edges:
+                        if edge.target == label:
+                            edge.target = target_label
+                            updated = True
+                    if updated:
+                        target.predecessors.add(predecessor_label)
+                    target.predecessors.discard(label)
+                self._delete_block(label, blocks)
+                changed = True
+                break
+
+    def _remove_critical_edges(self, blocks: MutableMapping[str, _MutableBlock]) -> None:
+        counter = 0
+        while True:
+            updated = False
+            for label, block in list(blocks.items()):
+                if len(block.edges) <= 1:
+                    continue
+                for edge in list(block.edges):
+                    target = blocks.get(edge.target)
+                    if target is None:
+                        continue
+                    if len(target.predecessors) <= 1:
+                        continue
+                    counter += 1
+                    new_label = f"{target.label}_split_{counter}"
+                    while new_label in blocks:
+                        counter += 1
+                        new_label = f"{target.label}_split_{counter}"
+                    split_block = _MutableBlock(
+                        label=new_label,
+                        start_offset=target.start_offset,
+                        statements=[],
+                        terminator=_GotoTerminator(target=target.label),
+                        edges=[_Edge("goto", target.label)],
+                        predecessors={block.label},
+                        synthetic=True,
+                    )
+                    blocks[new_label] = split_block
+                    edge.target = new_label
+                    target.predecessors.discard(block.label)
+                    target.predecessors.add(new_label)
+                    updated = True
+                if updated:
+                    break
+            if not updated:
+                break
+
+    def _fold_redundant_branches(self, blocks: MutableMapping[str, _MutableBlock]) -> None:
+        for block in blocks.values():
+            if not isinstance(
+                block.terminator,
+                (IRIf, IRTestSetBranch, IRFlagCheck, IRFunctionPrologue),
+            ):
+                continue
+            then_target = None
+            else_target = None
+            for edge in block.edges:
+                if edge.kind.endswith("then"):
+                    then_target = edge.target
+                elif edge.kind.endswith("else"):
+                    else_target = edge.target
+            if then_target is None or else_target is None:
+                continue
+            if then_target != else_target:
+                continue
+            block.edges = [_Edge("goto", then_target)]
+            block.terminator = _GotoTerminator(target=then_target)
+
+    # ------------------------------------------------------------------
+    # dominator analysis
+    # ------------------------------------------------------------------
+    def _compute_dominator_info(
+        self, entry: str, blocks: Mapping[str, _MutableBlock]
+    ) -> DominatorInfo:
+        succs, preds = self._build_succ_pred_maps(blocks)
+        order = self._reverse_postorder(entry, succs)
+        idom = self._compute_idoms(entry, order, preds)
+        dominators = self._dominators_from_idom(idom)
+        return DominatorInfo.freeze(entry, idom, dominators)
+
+    def _compute_post_dominator_info(
+        self, entry: str, blocks: Mapping[str, _MutableBlock]
+    ) -> DominatorInfo:
+        succs, preds = self._build_succ_pred_maps(blocks)
+        exits = [label for label, block in blocks.items() if not block.edges]
+        if not exits:
+            exits = [entry]
+        if len(exits) == 1:
+            root = exits[0]
+            rev_succs = {label: list(preds[label]) for label in blocks}
+            rev_preds = {label: set() for label in rev_succs}
+            for src, targets in rev_succs.items():
+                for target in targets:
+                    rev_preds[target].add(src)
+            order = self._reverse_postorder(root, rev_succs)
+            idom = self._compute_idoms(root, order, rev_preds)
+            dominators = self._dominators_from_idom(idom)
+            return DominatorInfo.freeze(root, idom, dominators)
+        sink = "__post_exit__"
+        rev_succs = {label: list(preds[label]) for label in blocks}
+        rev_succs[sink] = exits
+        rev_preds: Dict[str, Set[str]] = {label: set() for label in rev_succs}
+        for src, targets in rev_succs.items():
+            for target in targets:
+                rev_preds.setdefault(target, set()).add(src)
+        order = self._reverse_postorder(sink, rev_succs)
+        idom = self._compute_idoms(sink, order, rev_preds)
+        if sink in idom:
+            del idom[sink]
+        cleaned_idom: Dict[str, Optional[str]] = {}
+        for label, parent in idom.items():
+            if parent == sink:
+                cleaned_idom[label] = None
+            else:
+                cleaned_idom[label] = parent
+        dominators = self._dominators_from_idom(cleaned_idom)
+        return DominatorInfo.freeze(sink, cleaned_idom, dominators)
+
+    def _build_succ_pred_maps(
+        self, blocks: Mapping[str, _MutableBlock]
+    ) -> Tuple[Dict[str, List[str]], Dict[str, Set[str]]]:
+        succs: Dict[str, List[str]] = {}
+        preds: Dict[str, Set[str]] = {}
+        for label, block in blocks.items():
+            succs[label] = [edge.target for edge in block.edges]
+            preds.setdefault(label, set())
+            for edge in block.edges:
+                preds.setdefault(edge.target, set()).add(label)
+        return succs, preds
+
+    def _reverse_postorder(
+        self, root: str, succs: Mapping[str, Sequence[str]]
+    ) -> List[str]:
+        visited: Set[str] = set()
+        order: List[str] = []
+
+        def dfs(node: str) -> None:
+            if node in visited:
+                return
+            visited.add(node)
+            for target in succs.get(node, []):
+                dfs(target)
+            order.append(node)
+
+        dfs(root)
+        order.reverse()
+        return order
+
+    def _compute_idoms(
+        self,
+        root: str,
+        order: Sequence[str],
+        preds: Mapping[str, Set[str]],
+    ) -> Dict[str, Optional[str]]:
+        idom: Dict[str, Optional[str]] = {root: None}
+        for node in order:
+            if node == root:
+                continue
+            idom[node] = None
+        changed = True
+        rpo = [node for node in order if node in idom]
+        while changed:
+            changed = False
+            for node in rpo:
+                if node == root:
+                    continue
+                candidates = [
+                    pred
+                    for pred in preds.get(node, set())
+                    if pred in idom and (idom[pred] is not None or pred == root)
+                ]
+                if not candidates:
+                    continue
+                new_idom = candidates[0]
+                for pred in candidates[1:]:
+                    new_idom = self._intersect(pred, new_idom, idom)
+                if idom.get(node) != new_idom:
+                    idom[node] = new_idom
+                    changed = True
+        return idom
+
+    def _intersect(
+        self, finger_a: str, finger_b: str, idom: Mapping[str, Optional[str]]
+    ) -> str:
+        visited: Set[str] = set()
+        a = finger_a
+        while a is not None:
+            visited.add(a)
+            a = idom.get(a)
+        b = finger_b
+        while b is not None and b not in visited:
+            b = idom.get(b)
+        if b is None:
+            return finger_b
+        return b
+
+    def _dominators_from_idom(
+        self, idom: Mapping[str, Optional[str]]
+    ) -> Dict[str, List[str]]:
+        doms: Dict[str, List[str]] = {}
+        for node in idom:
+            doms[node] = []
+        for node in idom:
+            current = node
+            while current is not None:
+                doms[node].append(current)
+                current = idom.get(current)
+        return doms
+
+    # ------------------------------------------------------------------
+    # loop detection
+    # ------------------------------------------------------------------
+    def _identify_loops(
+        self, dominators: DominatorInfo, blocks: Mapping[str, _MutableBlock]
+    ) -> Tuple[ASTLoop, ...]:
+        idom = dominators.immediate
+        preds: Dict[str, Set[str]] = {}
+        succs: Dict[str, List[str]] = {}
+        for label, block in blocks.items():
+            succs[label] = [edge.target for edge in block.edges]
+            for edge in block.edges:
+                preds.setdefault(edge.target, set()).add(label)
+        loop_latches: Dict[Tuple[str, Tuple[str, ...]], Set[str]] = {}
+        dom_sets = dominators.dominators
+        for header in dominators.dominators:
+            for pred in preds.get(header, set()):
+                if header == pred:
+                    continue
+                pred_doms = dominators.dominators.get(pred, ())  # type: ignore[arg-type]
+                if header not in pred_doms:
+                    continue
+                loop_blocks = tuple(
+                    sorted(self._collect_loop(header, pred, preds, dom_sets))
+                )
+                key = (header, loop_blocks)
+                loop_latches.setdefault(key, set()).add(pred)
+        loops: List[ASTLoop] = []
+        for (header, blocks_tuple), latches in loop_latches.items():
+            loops.append(
+                ASTLoop(
+                    header=header,
+                    latches=tuple(sorted(latches)),
+                    blocks=blocks_tuple,
+                )
+            )
+        return tuple(sorted(loops, key=lambda loop: (loop.header, loop.blocks)))
+
+    def _collect_loop(
+        self,
+        header: str,
+        latch: str,
+        preds: Mapping[str, Set[str]],
+        dom_sets: Mapping[str, Sequence[str]],
+    ) -> List[str]:
+        loop_nodes: Set[str] = {header}
+        stack = [latch]
+        while stack:
+            node = stack.pop()
+            if node in loop_nodes:
+                continue
+            loop_nodes.add(node)
+            for pred in preds.get(node, set()):
+                if pred == header:
+                    loop_nodes.add(pred)
+                    continue
+                if header not in dom_sets.get(pred, ()):  # type: ignore[arg-type]
+                    continue
+                if pred not in loop_nodes:
+                    stack.append(pred)
+        return sorted(loop_nodes)
+
+    # ------------------------------------------------------------------
+    # freezing helpers
+    # ------------------------------------------------------------------
+    def _freeze_blocks(self, blocks: Mapping[str, _MutableBlock]) -> Tuple[ASTBlock, ...]:
+        frozen: List[ASTBlock] = []
+        for label in sorted(blocks.keys()):
+            block = blocks[label]
+            terminator = self._canonical_terminator(block)
+            frozen.append(
+                ASTBlock(
+                    label=block.label,
+                    start_offset=block.start_offset,
+                    statements=tuple(block.statements),
+                    terminator=terminator,
+                    predecessors=tuple(sorted(block.predecessors)),
+                    successors=tuple(sorted(edge.target for edge in block.edges)),
+                    synthetic=block.synthetic,
+                )
+            )
+        return tuple(frozen)
+
+    def _canonical_terminator(self, block: _MutableBlock) -> ASTTerminator:
+        targets = tuple(edge.target for edge in block.edges)
+        term = block.terminator
+        if isinstance(term, _GotoTerminator):
+            return ASTTerminator(kind="goto", targets=targets)
+        if isinstance(term, IRIf):
+            detail = {"condition": term.condition}
+            then_target = None
+            else_target = None
+            for edge in block.edges:
+                if edge.kind.endswith("then"):
+                    then_target = edge.target
+                elif edge.kind.endswith("else"):
+                    else_target = edge.target
+            if then_target is not None and else_target is not None and then_target != else_target:
+                return ASTTerminator(
+                    kind="if",
+                    targets=(then_target, else_target),
+                    detail=detail,
+                )
+            if then_target is not None:
+                return ASTTerminator(kind="goto", targets=(then_target,), detail=detail)
+        if isinstance(term, IRTestSetBranch):
+            detail = {
+                "var": term.var,
+                "expr": term.expr,
+            }
+            then_target = None
+            else_target = None
+            for edge in block.edges:
+                if edge.kind.endswith("then"):
+                    then_target = edge.target
+                elif edge.kind.endswith("else"):
+                    else_target = edge.target
+            if then_target is not None and else_target is not None and then_target != else_target:
+                return ASTTerminator(
+                    kind="testset",
+                    targets=(then_target, else_target),
+                    detail=detail,
+                )
+            if then_target is not None:
+                return ASTTerminator(kind="goto", targets=(then_target,), detail=detail)
+        if isinstance(term, IRFlagCheck):
+            detail = {"flag": term.flag}
+            then_target = None
+            else_target = None
+            for edge in block.edges:
+                if edge.kind.endswith("then"):
+                    then_target = edge.target
+                elif edge.kind.endswith("else"):
+                    else_target = edge.target
+            if then_target is not None and else_target is not None and then_target != else_target:
+                return ASTTerminator(
+                    kind="flag_check",
+                    targets=(then_target, else_target),
+                    detail=detail,
+                )
+            if then_target is not None:
+                return ASTTerminator(kind="goto", targets=(then_target,), detail=detail)
+        if isinstance(term, IRFunctionPrologue):
+            detail = {"var": term.var, "expr": term.expr}
+            then_target = None
+            else_target = None
+            for edge in block.edges:
+                if edge.kind.endswith("then"):
+                    then_target = edge.target
+                elif edge.kind.endswith("else"):
+                    else_target = edge.target
+            if then_target is not None and else_target is not None and then_target != else_target:
+                return ASTTerminator(
+                    kind="function_prologue",
+                    targets=(then_target, else_target),
+                    detail=detail,
+                )
+            if then_target is not None:
+                return ASTTerminator(kind="goto", targets=(then_target,), detail=detail)
+        if isinstance(term, IRSwitchDispatch):
+            return ASTTerminator(kind="switch", targets=targets, detail=term)
+        if isinstance(term, IRReturn):
+            return ASTTerminator(kind="return", targets=(), detail=term)
+        if isinstance(term, IRTailcallReturn):
+            return ASTTerminator(kind="tailcall_return", targets=(), detail=term)
+        if isinstance(term, IRTailCall):
+            return ASTTerminator(kind="tailcall", targets=targets, detail=term)
+        if isinstance(term, IRCallReturn):
+            predicate = getattr(term, "predicate", None)
+            detail = term
+            if predicate is not None:
+                detail = predicate.describe()
+                return ASTTerminator(
+                    kind="predicate",
+                    targets=targets,
+                    detail=detail,
+                )
+            return ASTTerminator(kind="call_return", targets=targets, detail=term)
+        if isinstance(term, IRTerminator):
+            if len(targets) == 1:
+                return ASTTerminator(kind="goto", targets=targets, detail=term)
+            return ASTTerminator(kind="terminator", targets=targets, detail=term)
+        if not targets:
+            return ASTTerminator(kind="halt", targets=targets, detail=term)
+        return ASTTerminator(kind="goto", targets=targets, detail=term)
+

--- a/mbcdisasm/ast/model.py
+++ b/mbcdisasm/ast/model.py
@@ -1,0 +1,107 @@
+"""Data structures for the high level abstract syntax tree stage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping, Optional, Sequence, Tuple
+
+from ..ir.model import IRNode
+
+
+@dataclass(frozen=True)
+class ASTTerminator:
+    """Canonical control-flow terminator description."""
+
+    kind: str
+    targets: Tuple[str, ...] = field(default_factory=tuple)
+    detail: Optional[object] = None
+
+    def describe(self) -> str:
+        """Return a stable textual description of the terminator."""
+
+        if self.kind == "goto" and self.targets:
+            return f"goto {self.targets[0]}"
+        if self.kind in {"return", "tailcall", "tailcall_return", "call_return"}:
+            node = self.detail
+            if isinstance(node, IRNode):
+                return node.describe()
+        if self.kind == "switch":
+            node = self.detail
+            if isinstance(node, IRNode):
+                return node.describe()
+            cases = ", ".join(self.targets)
+            return f"switch [{cases}]"
+        if self.kind == "predicate" and self.detail is not None:
+            return str(self.detail)
+        node = self.detail
+        if isinstance(node, IRNode):
+            return node.describe()
+        return self.kind
+
+
+@dataclass(frozen=True)
+class ASTBlock:
+    """Single block in the AST control-flow graph."""
+
+    label: str
+    start_offset: int
+    statements: Tuple[IRNode, ...]
+    terminator: ASTTerminator
+    predecessors: Tuple[str, ...]
+    successors: Tuple[str, ...]
+    synthetic: bool = False
+
+
+@dataclass(frozen=True)
+class DominatorInfo:
+    """Summary of a dominator/post-dominator tree."""
+
+    root: str
+    immediate: Mapping[str, Optional[str]]
+    dominators: Mapping[str, Tuple[str, ...]]
+
+    @staticmethod
+    def freeze(
+        root: str,
+        immediate: Mapping[str, Optional[str]],
+        dominators: Mapping[str, Sequence[str]],
+    ) -> "DominatorInfo":
+        """Create an immutable instance from mutable mappings."""
+
+        immut_idom = MappingProxyType(dict(immediate))
+        immut_dom = MappingProxyType({
+            block: tuple(sorted(doms)) for block, doms in dominators.items()
+        })
+        return DominatorInfo(root=root, immediate=immut_idom, dominators=immut_dom)
+
+
+@dataclass(frozen=True)
+class ASTLoop:
+    """Description of a natural loop detected in the CFG."""
+
+    header: str
+    latches: Tuple[str, ...]
+    blocks: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ASTFunction:
+    """High level representation of a single function."""
+
+    segment_index: int
+    name: str
+    entry_block: str
+    entry_offset: int
+    blocks: Tuple[ASTBlock, ...]
+    dominators: DominatorInfo
+    post_dominators: DominatorInfo
+    loops: Tuple[ASTLoop, ...]
+
+
+@dataclass(frozen=True)
+class ASTProgram:
+    """High level AST representation for the entire container."""
+
+    functions: Tuple[ASTFunction, ...]
+

--- a/mbcdisasm/ast/renderer.py
+++ b/mbcdisasm/ast/renderer.py
@@ -1,0 +1,66 @@
+"""Rendering helpers for the AST representation."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .model import ASTBlock, ASTFunction, ASTProgram
+
+
+def _describe_node(node) -> str:
+    describe = getattr(node, "describe", None)
+    if callable(describe):
+        return describe()
+    return repr(node)
+
+
+class ASTRenderer:
+    """Render the AST into a stable textual format."""
+
+    def render(self, program: ASTProgram) -> str:
+        lines: List[str] = []
+        for function in program.functions:
+            self._render_function(function, lines)
+        return "\n".join(lines)
+
+    def _render_function(self, function: ASTFunction, lines: List[str]) -> None:
+        header = (
+            f"function {function.name} segment={function.segment_index} "
+            f"entry={function.entry_block} offset=0x{function.entry_offset:04X}"
+        )
+        lines.append(header)
+        lines.append("  blocks:")
+        for block in function.blocks:
+            self._render_block(block, lines)
+        self._render_dominators("dominators", function.dominators, lines)
+        self._render_dominators("post_dominators", function.post_dominators, lines)
+        if function.loops:
+            lines.append("  loops:")
+            for loop in function.loops:
+                loop_line = (
+                    f"    header={loop.header} latches=[{', '.join(loop.latches)}] "
+                    f"blocks=[{', '.join(loop.blocks)}]"
+                )
+                lines.append(loop_line)
+        lines.append("")
+
+    def _render_block(self, block: ASTBlock, lines: List[str]) -> None:
+        preds = ", ".join(block.predecessors)
+        succs = ", ".join(block.successors)
+        synthetic = " synthetic" if block.synthetic else ""
+        lines.append(
+            f"    block {block.label} offset=0x{block.start_offset:04X} "
+            f"preds=[{preds}] succs=[{succs}]{synthetic}"
+        )
+        for statement in block.statements:
+            lines.append(f"      {_describe_node(statement)}")
+        lines.append(f"      terminator {block.terminator.describe()}")
+
+    def _render_dominators(self, title, info, lines: List[str]) -> None:
+        lines.append(f"  {title} (root={info.root}):")
+        for block in sorted(info.dominators.keys()):
+            idom = info.immediate.get(block)
+            idom_text = idom if idom is not None else "-"
+            doms = ", ".join(info.dominators[block])
+            lines.append(f"    {block}: idom={idom_text} dom=[{doms}]")
+

--- a/tests/test_ast_builder.py
+++ b/tests/test_ast_builder.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from mbcdisasm.ast import ASTBuilder
+from mbcdisasm.ir.model import (
+    IRBlock,
+    IRCfgBlock,
+    IRCfgEdge,
+    IRControlFlowGraph,
+    IRFunctionCfg,
+    IRIf,
+    IRLiteral,
+    IRProgram,
+    IRReturn,
+    IRSegment,
+    IRTerminator,
+    NormalizerMetrics,
+)
+
+
+def _make_program(blocks: list[IRBlock], cfg_blocks: list[IRCfgBlock]) -> IRProgram:
+    segment = IRSegment(
+        index=0,
+        start=0,
+        length=0,
+        blocks=tuple(blocks),
+        metrics=NormalizerMetrics(),
+    )
+    function = IRFunctionCfg(
+        segment_index=0,
+        name="test",
+        entry_block=cfg_blocks[0].label,
+        entry_offset=cfg_blocks[0].start_offset,
+        blocks=tuple(cfg_blocks),
+    )
+    cfg = IRControlFlowGraph(functions=(function,))
+    return IRProgram(
+        segments=(segment,),
+        metrics=NormalizerMetrics(),
+        cfg=cfg,
+    )
+
+
+def test_ast_builder_computes_dominators_and_loops() -> None:
+    entry = IRBlock(
+        label="entry",
+        start_offset=0x0000,
+        nodes=(IRTerminator(operand=0),),
+    )
+    header = IRBlock(
+        label="loop_header",
+        start_offset=0x0010,
+        nodes=(IRIf(condition="cond", then_target=0x20, else_target=0x30),),
+    )
+    body = IRBlock(
+        label="loop_body",
+        start_offset=0x0020,
+        nodes=(
+            IRLiteral(value=1, mode=0, source="test"),
+            IRTerminator(operand=0),
+        ),
+    )
+    exit_block = IRBlock(
+        label="exit",
+        start_offset=0x0030,
+        nodes=(IRReturn(values=("x",),),),
+    )
+
+    cfg_blocks = [
+        IRCfgBlock(
+            label="entry",
+            start_offset=0x0000,
+            terminator="goto",
+            edges=(IRCfgEdge("goto", "loop_header"),),
+        ),
+        IRCfgBlock(
+            label="loop_header",
+            start_offset=0x0010,
+            terminator="if",
+            edges=(
+                IRCfgEdge("then", "loop_body"),
+                IRCfgEdge("else", "exit"),
+            ),
+        ),
+        IRCfgBlock(
+            label="loop_body",
+            start_offset=0x0020,
+            terminator="goto",
+            edges=(IRCfgEdge("goto", "loop_header"),),
+        ),
+        IRCfgBlock(
+            label="exit",
+            start_offset=0x0030,
+            terminator="return",
+            edges=tuple(),
+        ),
+    ]
+
+    program = _make_program([entry, header, body, exit_block], cfg_blocks)
+    builder = ASTBuilder()
+    ast_program = builder.build(program)
+
+    function = ast_program.functions[0]
+    assert function.dominators.immediate["entry"] is None
+    assert function.dominators.immediate["loop_header"] == "entry"
+    assert function.dominators.immediate["loop_body"] == "loop_header"
+    assert function.dominators.immediate["exit"] == "loop_header"
+
+    assert len(function.loops) == 1
+    loop = function.loops[0]
+    assert loop.header == "loop_header"
+    assert loop.latches == ("loop_body",)
+    assert set(loop.blocks) == {"loop_header", "loop_body"}
+
+
+def test_ast_builder_splits_critical_edges() -> None:
+    entry = IRBlock(
+        label="entry",
+        start_offset=0x0000,
+        nodes=(IRIf(condition="c0", then_target=0x10, else_target=0x20),),
+    )
+    block_a = IRBlock(
+        label="block_a",
+        start_offset=0x0010,
+        nodes=(IRIf(condition="c1", then_target=0x30, else_target=0x40),),
+    )
+    block_b = IRBlock(
+        label="block_b",
+        start_offset=0x0020,
+        nodes=(IRLiteral(value=2, mode=0, source="b"), IRTerminator(operand=0)),
+    )
+    block_c = IRBlock(
+        label="block_c",
+        start_offset=0x0030,
+        nodes=(IRLiteral(value=3, mode=0, source="c"), IRTerminator(operand=0)),
+    )
+    join = IRBlock(
+        label="join",
+        start_offset=0x0040,
+        nodes=(IRReturn(values=("y",),),),
+    )
+
+    cfg_blocks = [
+        IRCfgBlock(
+            label="entry",
+            start_offset=0x0000,
+            terminator="if",
+            edges=(IRCfgEdge("then", "block_a"), IRCfgEdge("else", "block_b")),
+        ),
+        IRCfgBlock(
+            label="block_a",
+            start_offset=0x0010,
+            terminator="if",
+            edges=(
+                IRCfgEdge("then", "join"),
+                IRCfgEdge("else", "block_c"),
+            ),
+        ),
+        IRCfgBlock(
+            label="block_b",
+            start_offset=0x0020,
+            terminator="goto",
+            edges=(IRCfgEdge("goto", "join"),),
+        ),
+        IRCfgBlock(
+            label="block_c",
+            start_offset=0x0030,
+            terminator="goto",
+            edges=(IRCfgEdge("goto", "join"),),
+        ),
+        IRCfgBlock(
+            label="join",
+            start_offset=0x0040,
+            terminator="return",
+            edges=tuple(),
+        ),
+    ]
+
+    program = _make_program([entry, block_a, block_b, block_c, join], cfg_blocks)
+    builder = ASTBuilder()
+    ast_program = builder.build(program)
+    function = ast_program.functions[0]
+
+    synthetic_blocks = [block for block in function.blocks if block.synthetic]
+    assert synthetic_blocks, "expected critical edges to be split"
+    join_split = [block for block in synthetic_blocks if "join" in block.label]
+    assert join_split
+    for block in join_split:
+        assert block.terminator.kind == "goto"
+        assert block.successors == ("join",)
+
+
+def test_branch_folding_to_goto() -> None:
+    entry = IRBlock(
+        label="entry",
+        start_offset=0x0000,
+        nodes=(
+            IRIf(condition="always", then_target=0x10, else_target=0x10),
+        ),
+    )
+    target = IRBlock(
+        label="target",
+        start_offset=0x0010,
+        nodes=(IRReturn(values=("z",),),),
+    )
+
+    cfg_blocks = [
+        IRCfgBlock(
+            label="entry",
+            start_offset=0x0000,
+            terminator="if",
+            edges=(
+                IRCfgEdge("then", "target"),
+                IRCfgEdge("else", "target"),
+            ),
+        ),
+        IRCfgBlock(
+            label="target",
+            start_offset=0x0010,
+            terminator="return",
+            edges=tuple(),
+        ),
+    ]
+
+    program = _make_program([entry, target], cfg_blocks)
+    builder = ASTBuilder()
+    ast_program = builder.build(program)
+
+    function = ast_program.functions[0]
+    entry_block = next(block for block in function.blocks if block.label == "entry")
+    assert entry_block.terminator.kind == "goto"
+    assert entry_block.terminator.targets == ("target",)
+


### PR DESCRIPTION
## Summary
- add a dedicated AST package that builds high level functions from the normalised IR
- compute dominator and post-dominator trees, natural loops, and normalise control-flow during AST construction
- expose AST builder/renderer at the package level and provide tests for critical edge splitting, loop detection, and branch folding

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd9f0d4f4832f9472a97dd65a8658)