### PR TITLE
Add AST construction phase with CFG normalisation

### DIFF
--- a/mbcdisasm/__init__.py
+++ b/mbcdisasm/__init__.py
@@ -4,6 +4,7 @@ from .adb import SegmentDescriptor, SegmentIndex
 from .disassembler import Disassembler
 from .instruction import InstructionWord
 from .ir import IRNormalizer, IRTextRenderer
+from .ast import ASTBuilder, ASTRenderer
 from .knowledge import KnowledgeBase
 from .mbc import MbcContainer, Segment
 
@@ -16,5 +17,7 @@ __all__ = [
     "MbcContainer",
     "Segment",
     "IRNormalizer",
-    "IRTextRenderer"
+    "IRTextRenderer",
+    "ASTBuilder",
+    "ASTRenderer",
 ]

--- a/mbcdisasm/ast/__init__.py
+++ b/mbcdisasm/ast/__init__.py
@@ -1,0 +1,25 @@
+"""Public exports for the AST phase."""
+
+from .builder import ASTBuilder
+from .model import (
+    ASTBlock,
+    ASTDominatorInfo,
+    ASTFunction,
+    ASTLoop,
+    ASTProgram,
+    ASTSwitchCase,
+    ASTTerminator,
+)
+from .renderer import ASTRenderer
+
+__all__ = [
+    "ASTBuilder",
+    "ASTRenderer",
+    "ASTBlock",
+    "ASTDominatorInfo",
+    "ASTFunction",
+    "ASTLoop",
+    "ASTProgram",
+    "ASTSwitchCase",
+    "ASTTerminator",
+]

--- a/mbcdisasm/ast/builder.py
+++ b/mbcdisasm/ast/builder.py
@@ -1,0 +1,626 @@
+"""Construction helpers for transforming CFGs into structured ASTs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, List, Mapping, MutableMapping, MutableSet, Optional, Sequence, Set, Tuple
+
+from ..ir.cfg import analyse_segments
+from ..ir.model import (
+    IRBlock,
+    IRCallReturn,
+    IRFunctionCfg,
+    IRIf,
+    IRReturn,
+    IRSegment,
+    IRSwitchDispatch,
+    IRTestSetBranch,
+    IRFlagCheck,
+    IRFunctionPrologue,
+    IRTailCall,
+    IRTailcallReturn,
+    IRTerminator,
+    IRNode,
+)
+from .model import (
+    ASTBlock,
+    ASTDominatorInfo,
+    ASTFunction,
+    ASTLoop,
+    ASTProgram,
+    ASTSwitchCase,
+    ASTTerminator,
+)
+
+
+_TERMINATOR_TYPES = (
+    IRReturn,
+    IRTailCall,
+    IRTailcallReturn,
+    IRCallReturn,
+    IRIf,
+    IRTestSetBranch,
+    IRFlagCheck,
+    IRFunctionPrologue,
+    IRSwitchDispatch,
+    IRTerminator,
+)
+
+
+@dataclass
+class _MutableBlock:
+    label: str
+    start_offset: int
+    body: Tuple[IRNode, ...]
+    terminator: ASTTerminator
+    predecessors: MutableSet[str]
+    successors: MutableSet[str]
+
+    def to_ast_block(self) -> ASTBlock:
+        return ASTBlock(
+            label=self.label,
+            start_offset=self.start_offset,
+            body=self.body,
+            terminator=self.terminator,
+            predecessors=tuple(sorted(self.predecessors)),
+            successors=tuple(sorted(self.successors)),
+        )
+
+
+class ASTBuilder:
+    """Build an :class:`ASTProgram` from a normalised :class:`IRProgram`."""
+
+    def build(self, program) -> ASTProgram:
+        cfg, _ = analyse_segments(program.segments)
+        block_lookup = self._build_block_lookup(program.segments)
+        functions: List[ASTFunction] = []
+        for function_cfg in cfg.functions:
+            function = self._build_function(function_cfg, block_lookup)
+            if function.blocks:
+                functions.append(function)
+        return ASTProgram(functions=tuple(functions))
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _build_block_lookup(
+        self, segments: Sequence[IRSegment]
+    ) -> Dict[Tuple[int, str], IRBlock]:
+        lookup: Dict[Tuple[int, str], IRBlock] = {}
+        for segment in segments:
+            for block in segment.blocks:
+                lookup[(segment.index, block.label)] = block
+        return lookup
+
+    def _build_function(
+        self,
+        function_cfg: IRFunctionCfg,
+        block_lookup: Mapping[Tuple[int, str], IRBlock],
+    ) -> ASTFunction:
+        segment_index = function_cfg.segment_index
+        function_labels = {cfg_block.label for cfg_block in function_cfg.blocks}
+        if not function_labels:
+            return ASTFunction(
+                segment_index=segment_index,
+                name=function_cfg.name,
+                entry=function_cfg.entry_block,
+                blocks=tuple(),
+                dominators=tuple(),
+                post_dominators=tuple(),
+                loops=tuple(),
+            )
+
+        offset_map = {
+            block_lookup[(segment_index, label)].start_offset: label
+            for label in function_labels
+        }
+
+        blocks: Dict[str, _MutableBlock] = {}
+        for cfg_block in function_cfg.blocks:
+            ir_block = block_lookup[(segment_index, cfg_block.label)]
+            mutable = self._make_mutable_block(ir_block, offset_map)
+            mutable.successors.update(edge.target for edge in cfg_block.edges)
+            blocks[mutable.label] = mutable
+
+        for block in blocks.values():
+            block.predecessors.clear()
+        for block in blocks.values():
+            for succ in list(block.successors):
+                if succ not in blocks:
+                    block.successors.discard(succ)
+                    continue
+                blocks[succ].predecessors.add(block.label)
+
+        entry = function_cfg.entry_block
+        if entry not in blocks:
+            return ASTFunction(
+                segment_index=segment_index,
+                name=function_cfg.name,
+                entry=entry,
+                blocks=tuple(),
+                dominators=tuple(),
+                post_dominators=tuple(),
+                loops=tuple(),
+            )
+
+        self._remove_unreachable(blocks, entry)
+        self._split_critical_edges(blocks)
+        self._merge_degenerate_blocks(blocks, entry)
+        self._fold_redundant_branches(blocks)
+
+        dominators = self._compute_dominators(blocks, entry)
+        post_dominators = self._compute_post_dominators(blocks)
+        loops = self._identify_loops(blocks, dominators)
+
+        ast_blocks = tuple(
+            sorted(
+                (block.to_ast_block() for block in blocks.values()),
+                key=lambda item: (item.start_offset, item.label),
+            )
+        )
+
+        dom_info = self._build_dom_info(dominators, entry)
+        post_dom_info = self._build_post_dom_info(post_dominators, entry)
+
+        return ASTFunction(
+            segment_index=segment_index,
+            name=function_cfg.name,
+            entry=entry,
+            blocks=ast_blocks,
+            dominators=dom_info,
+            post_dominators=post_dom_info,
+            loops=loops,
+        )
+
+    def _make_mutable_block(
+        self, block: IRBlock, offset_map: Mapping[int, str]
+    ) -> _MutableBlock:
+        nodes = list(block.nodes)
+        terminator_node: Optional[IRNode] = None
+        for index in range(len(nodes) - 1, -1, -1):
+            if isinstance(nodes[index], _TERMINATOR_TYPES):
+                terminator_node = nodes.pop(index)
+                break
+        body = tuple(nodes)
+        terminator = self._build_terminator(terminator_node, offset_map)
+        return _MutableBlock(
+            label=block.label,
+            start_offset=block.start_offset,
+            body=body,
+            terminator=terminator,
+            predecessors=set(),
+            successors=set(),
+        )
+
+    def _build_terminator(
+        self, node: Optional[IRNode], offset_map: Mapping[int, str]
+    ) -> ASTTerminator:
+        if node is None:
+            return ASTTerminator(kind="none")
+        if isinstance(node, IRReturn):
+            return ASTTerminator(kind="return", origin=node, description=node.describe())
+        if isinstance(node, IRTailCall):
+            return ASTTerminator(kind="tailcall", origin=node, description=node.describe())
+        if isinstance(node, IRTailcallReturn):
+            return ASTTerminator(
+                kind="tailcall_return",
+                origin=node,
+                description=node.describe(),
+            )
+        if isinstance(node, IRCallReturn):
+            then_target = None
+            else_target = None
+            branch_kind = None
+            condition = None
+            if node.predicate is not None:
+                branch_kind = node.predicate.kind
+                condition = node.predicate.describe()
+                then_target = self._resolve_target(node.predicate.then_target, offset_map)
+                else_target = self._resolve_target(node.predicate.else_target, offset_map)
+            return ASTTerminator(
+                kind="call_return",
+                origin=node,
+                description=node.describe(),
+                then_target=then_target,
+                else_target=else_target,
+                branch_kind=branch_kind,
+                condition=condition,
+            )
+        if isinstance(node, IRIf):
+            return ASTTerminator(
+                kind="branch",
+                origin=node,
+                branch_kind="if",
+                condition=node.condition,
+                then_target=self._resolve_target(node.then_target, offset_map),
+                else_target=self._resolve_target(node.else_target, offset_map),
+            )
+        if isinstance(node, IRTestSetBranch):
+            return ASTTerminator(
+                kind="branch",
+                origin=node,
+                branch_kind="testset",
+                condition=f"{node.var}={node.expr}",
+                then_target=self._resolve_target(node.then_target, offset_map),
+                else_target=self._resolve_target(node.else_target, offset_map),
+            )
+        if isinstance(node, IRFlagCheck):
+            return ASTTerminator(
+                kind="branch",
+                origin=node,
+                branch_kind="flag",
+                condition=f"0x{node.flag:04X}",
+                then_target=self._resolve_target(node.then_target, offset_map),
+                else_target=self._resolve_target(node.else_target, offset_map),
+            )
+        if isinstance(node, IRFunctionPrologue):
+            return ASTTerminator(
+                kind="branch",
+                origin=node,
+                branch_kind="prologue",
+                condition=f"{node.var}={node.expr}",
+                then_target=self._resolve_target(node.then_target, offset_map),
+                else_target=self._resolve_target(node.else_target, offset_map),
+            )
+        if isinstance(node, IRSwitchDispatch):
+            cases = tuple(
+                ASTSwitchCase(
+                    key=str(case.key),
+                    target=self._resolve_target(case.target, offset_map) or f"0x{case.target:04X}",
+                )
+                for case in node.cases
+            )
+            default_target = self._resolve_target(node.default, offset_map)
+            return ASTTerminator(
+                kind="switch",
+                origin=node,
+                description=node.describe(),
+                cases=cases,
+                default_target=default_target,
+            )
+        if isinstance(node, IRTerminator):
+            return ASTTerminator(
+                kind="terminator",
+                origin=node,
+                description=node.describe(),
+            )
+        return ASTTerminator(kind="unknown", origin=node)
+
+    def _resolve_target(self, target: Optional[int], offset_map: Mapping[int, str]) -> Optional[str]:
+        if target is None:
+            return None
+        return offset_map.get(target, f"0x{target:04X}")
+
+    # ------------------------------------------------------------------
+    # graph clean-up helpers
+    # ------------------------------------------------------------------
+    def _remove_unreachable(self, blocks: MutableMapping[str, _MutableBlock], entry: str) -> None:
+        if entry not in blocks:
+            return
+        reachable: Set[str] = set()
+        worklist = [entry]
+        while worklist:
+            label = worklist.pop()
+            if label in reachable:
+                continue
+            reachable.add(label)
+            worklist.extend(blocks[label].successors)
+        for label in list(blocks.keys()):
+            if label in reachable:
+                continue
+            for block in blocks.values():
+                block.predecessors.discard(label)
+                block.successors.discard(label)
+            del blocks[label]
+
+    def _split_critical_edges(self, blocks: MutableMapping[str, _MutableBlock]) -> None:
+        counter = 0
+        for block in list(blocks.values()):
+            successors = list(block.successors)
+            if len(successors) <= 1:
+                continue
+            for target in successors:
+                if target not in blocks:
+                    continue
+                successor = blocks[target]
+                if len(successor.predecessors) <= 1:
+                    continue
+                new_label = f"{block.label}_split_{counter}"
+                counter += 1
+                while new_label in blocks:
+                    new_label = f"{block.label}_split_{counter}"
+                    counter += 1
+                splitter = _MutableBlock(
+                    label=new_label,
+                    start_offset=successor.start_offset,
+                    body=tuple(),
+                    terminator=ASTTerminator(
+                        kind="jump",
+                        target=target,
+                        description=f"critical_edge {block.label}->{target}",
+                    ),
+                    predecessors={block.label},
+                    successors={target},
+                )
+                blocks[new_label] = splitter
+                block.successors.remove(target)
+                block.successors.add(new_label)
+                successor.predecessors.remove(block.label)
+                successor.predecessors.add(new_label)
+                block.terminator = self._redirect_terminator(
+                    block.terminator, target, new_label
+                )
+
+    def _merge_degenerate_blocks(
+        self, blocks: MutableMapping[str, _MutableBlock], entry: str
+    ) -> None:
+        changed = True
+        while changed:
+            changed = False
+            for label, block in list(blocks.items()):
+                if label == entry:
+                    continue
+                if block.body:
+                    continue
+                if block.terminator.kind != "jump":
+                    continue
+                if len(block.successors) != 1:
+                    continue
+                if len(block.predecessors) != 1:
+                    continue
+                target = next(iter(block.successors))
+                if target not in blocks:
+                    continue
+                successor = blocks[target]
+                if len(successor.predecessors) != 1:
+                    continue
+                predecessors = list(block.predecessors)
+                for pred_label in predecessors:
+                    if pred_label not in blocks:
+                        continue
+                    pred = blocks[pred_label]
+                    if label in pred.successors:
+                        pred.successors.remove(label)
+                        pred.successors.add(target)
+                    successor.predecessors.add(pred_label)
+                successor.predecessors.discard(label)
+                del blocks[label]
+                changed = True
+                break
+        for block in blocks.values():
+            block.predecessors.intersection_update(blocks.keys())
+            block.successors.intersection_update(blocks.keys())
+
+    def _fold_redundant_branches(self, blocks: MutableMapping[str, _MutableBlock]) -> None:
+        for block in blocks.values():
+            term = block.terminator
+            if term.kind != "branch":
+                continue
+            current_successors = list(block.successors)
+            for successor in current_successors:
+                if successor in blocks:
+                    blocks[successor].predecessors.discard(block.label)
+            then_target = term.then_target
+            else_target = term.else_target
+            if then_target is not None and then_target == else_target:
+                block.terminator = ASTTerminator(
+                    kind="jump",
+                    origin=term.origin,
+                    description=term.description,
+                    target=then_target,
+                )
+                new_successors = {then_target} if then_target is not None else set()
+                block.successors = new_successors
+            else:
+                successors = {
+                    target
+                    for target in (then_target, else_target)
+                    if target is not None and target in blocks
+                }
+                block.successors = successors
+            for successor in block.successors:
+                if successor in blocks:
+                    blocks[successor].predecessors.add(block.label)
+
+    # ------------------------------------------------------------------
+    # dominator analysis
+    # ------------------------------------------------------------------
+    def _compute_dominators(
+        self, blocks: Mapping[str, _MutableBlock], entry: str
+    ) -> Mapping[str, Set[str]]:
+        dom: Dict[str, Set[str]] = {
+            label: set(blocks.keys()) for label in blocks
+        }
+        dom[entry] = {entry}
+        changed = True
+        while changed:
+            changed = False
+            for label, block in blocks.items():
+                if label == entry:
+                    continue
+                preds = [blocks[pred] for pred in block.predecessors if pred in blocks]
+                if not preds:
+                    new_set = {label}
+                else:
+                    intersect = set(blocks.keys())
+                    for pred in preds:
+                        intersect &= dom[pred.label]
+                    new_set = {label} | intersect
+                if new_set != dom[label]:
+                    dom[label] = new_set
+                    changed = True
+        return dom
+
+    def _compute_post_dominators(
+        self, blocks: Mapping[str, _MutableBlock]
+    ) -> Mapping[str, Set[str]]:
+        labels = set(blocks.keys())
+        exits = [label for label, block in blocks.items() if not block.successors]
+        if not exits:
+            exits = list(labels)
+        pdom: Dict[str, Set[str]] = {label: set(labels) for label in labels}
+        for exit_label in exits:
+            pdom[exit_label] = {exit_label}
+        changed = True
+        while changed:
+            changed = False
+            for label, block in blocks.items():
+                if label in exits:
+                    continue
+                succs = [succ for succ in block.successors if succ in blocks]
+                if not succs:
+                    new_set = {label}
+                else:
+                    intersect = set(labels)
+                    for succ in succs:
+                        intersect &= pdom[succ]
+                    new_set = {label} | intersect
+                if new_set != pdom[label]:
+                    pdom[label] = new_set
+                    changed = True
+        return pdom
+
+    def _identify_loops(
+        self,
+        blocks: Mapping[str, _MutableBlock],
+        dominators: Mapping[str, Set[str]],
+    ) -> Tuple[ASTLoop, ...]:
+        loops: Dict[str, Dict[str, Set[str]]] = {}
+        for label, block in blocks.items():
+            for succ in block.successors:
+                if succ not in blocks:
+                    continue
+                if succ not in dominators.get(label, set()):
+                    continue
+                loop = loops.setdefault(
+                    succ, {"nodes": set([succ]), "latches": set()}
+                )
+                loop["latches"].add(label)
+                loop_nodes = self._collect_natural_loop(blocks, succ, label)
+                loop["nodes"].update(loop_nodes)
+        ast_loops = [
+            ASTLoop(
+                header=header,
+                nodes=tuple(sorted(data["nodes"])),
+                latches=tuple(sorted(data["latches"])),
+            )
+            for header, data in loops.items()
+        ]
+        ast_loops.sort(key=lambda loop: loop.header)
+        return tuple(ast_loops)
+
+    def _collect_natural_loop(
+        self,
+        blocks: Mapping[str, _MutableBlock],
+        header: str,
+        latch: str,
+    ) -> Set[str]:
+        nodes = {header, latch}
+        worklist = [latch]
+        while worklist:
+            current = worklist.pop()
+            for pred in blocks[current].predecessors:
+                if pred == header or pred in nodes:
+                    continue
+                nodes.add(pred)
+                worklist.append(pred)
+        return nodes
+
+    def _build_dom_info(
+        self,
+        dom: Mapping[str, Set[str]],
+        entry: str,
+    ) -> Tuple[ASTDominatorInfo, ...]:
+        info: List[ASTDominatorInfo] = []
+        idom = self._compute_immediate(dom, entry)
+        for label, dominators in dom.items():
+            info.append(
+                ASTDominatorInfo(
+                    block=label,
+                    dominators=tuple(sorted(dominators)),
+                    immediate=idom.get(label),
+                )
+            )
+        info.sort(key=lambda item: item.block)
+        return tuple(info)
+
+    def _build_post_dom_info(
+        self,
+        pdom: Mapping[str, Set[str]],
+        entry: str,
+    ) -> Tuple[ASTDominatorInfo, ...]:
+        # Entry is not special for post-dominators; reuse helper with virtual root
+        info: List[ASTDominatorInfo] = []
+        ipdom = self._compute_immediate(pdom, None)
+        for label, postdoms in pdom.items():
+            info.append(
+                ASTDominatorInfo(
+                    block=label,
+                    dominators=tuple(sorted(postdoms)),
+                    immediate=ipdom.get(label),
+                )
+            )
+        info.sort(key=lambda item: item.block)
+        return tuple(info)
+
+    def _compute_immediate(
+        self,
+        dom: Mapping[str, Set[str]],
+        entry: Optional[str],
+    ) -> Mapping[str, Optional[str]]:
+        result: Dict[str, Optional[str]] = {}
+        for label in dom:
+            if entry is not None and label == entry:
+                result[label] = None
+                continue
+            candidates = dom[label] - {label}
+            immediate: Optional[str] = None
+            for candidate in candidates:
+                others = candidates - {candidate}
+                if all(candidate not in (dom[other] - {other}) for other in others):
+                    if immediate is None:
+                        immediate = candidate
+                    elif len(dom[candidate]) > len(dom[immediate]):
+                        immediate = candidate
+            result[label] = immediate
+        return result
+
+    def _redirect_terminator(
+        self, terminator: ASTTerminator, old: str, new: str
+    ) -> ASTTerminator:
+        if terminator.kind == "branch":
+            if terminator.then_target == old:
+                terminator = replace(terminator, then_target=new)
+            if terminator.else_target == old:
+                terminator = replace(terminator, else_target=new)
+            return terminator
+        if terminator.kind == "call_return":
+            if terminator.then_target == old:
+                terminator = replace(terminator, then_target=new)
+            if terminator.else_target == old:
+                terminator = replace(terminator, else_target=new)
+            return terminator
+        if terminator.kind == "switch":
+            changed = False
+            updated_cases = []
+            for case in terminator.cases:
+                if case.target == old:
+                    updated_cases.append(ASTSwitchCase(case.key, new))
+                    changed = True
+                else:
+                    updated_cases.append(case)
+            default_target = terminator.default_target
+            if default_target == old:
+                default_target = new
+                changed = True
+            if changed:
+                terminator = replace(
+                    terminator,
+                    cases=tuple(updated_cases),
+                    default_target=default_target,
+                )
+            return terminator
+        return terminator
+
+
+__all__ = ["ASTBuilder"]

--- a/mbcdisasm/ast/model.py
+++ b/mbcdisasm/ast/model.py
@@ -1,0 +1,127 @@
+"""High-level AST representation derived from the normalised IR."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from ..ir.model import IRNode
+
+
+@dataclass(frozen=True)
+class ASTSwitchCase:
+    """Single case in a structured switch terminator."""
+
+    key: str
+    target: str
+
+
+@dataclass(frozen=True)
+class ASTTerminator:
+    """Canonical description of structured control-flow exits."""
+
+    kind: str
+    origin: Optional[IRNode] = None
+    description: Optional[str] = None
+    target: Optional[str] = None
+    then_target: Optional[str] = None
+    else_target: Optional[str] = None
+    branch_kind: Optional[str] = None
+    condition: Optional[str] = None
+    cases: Tuple[ASTSwitchCase, ...] = tuple()
+    default_target: Optional[str] = None
+
+    def describe(self) -> str:
+        """Render the terminator into a stable textual description."""
+
+        if self.kind == "jump":
+            target = self.target or "?"
+            return f"jump -> {target}"
+        if self.kind == "branch":
+            cond = self.condition or "?"
+            then_target = self.then_target or "?"
+            else_target = self.else_target or "?"
+            prefix = "branch"
+            if self.branch_kind:
+                prefix += f"[{self.branch_kind}]"
+            return f"{prefix} {cond} then={then_target} else={else_target}"
+        if self.kind == "switch":
+            rendered_cases = ", ".join(f"{case.key}->{case.target}" for case in self.cases)
+            default = self.default_target or "?"
+            return f"switch cases=[{rendered_cases}] default={default}"
+        if self.kind in {"return", "tailcall", "tailcall_return", "call_return", "terminator"}:
+            if self.description:
+                return self.description
+            if self.origin is not None:
+                describe = getattr(self.origin, "describe", None)
+                if callable(describe):
+                    return describe()
+            return self.kind
+        if self.description:
+            return self.description
+        if self.origin is not None:
+            describe = getattr(self.origin, "describe", None)
+            if callable(describe):
+                return describe()
+        return self.kind or "?"
+
+
+@dataclass(frozen=True)
+class ASTBlock:
+    """Structured basic block with canonical control-flow metadata."""
+
+    label: str
+    start_offset: int
+    body: Tuple[IRNode, ...]
+    terminator: ASTTerminator
+    predecessors: Tuple[str, ...]
+    successors: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ASTDominatorInfo:
+    """Summary of dominator relationships for a single block."""
+
+    block: str
+    dominators: Tuple[str, ...]
+    immediate: Optional[str]
+
+
+@dataclass(frozen=True)
+class ASTLoop:
+    """Natural loop recovered from the CFG."""
+
+    header: str
+    nodes: Tuple[str, ...]
+    latches: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ASTFunction:
+    """Structured view of a single function body."""
+
+    segment_index: int
+    name: str
+    entry: str
+    blocks: Tuple[ASTBlock, ...]
+    dominators: Tuple[ASTDominatorInfo, ...]
+    post_dominators: Tuple[ASTDominatorInfo, ...]
+    loops: Tuple[ASTLoop, ...]
+
+
+@dataclass(frozen=True)
+class ASTProgram:
+    """Top-level structured representation for the entire container."""
+
+    functions: Tuple[ASTFunction, ...]
+
+
+__all__ = [
+    "ASTBlock",
+    "ASTDominatorInfo",
+    "ASTFunction",
+    "ASTLoop",
+    "ASTProgram",
+    "ASTSwitchCase",
+    "ASTTerminator",
+]

--- a/mbcdisasm/ast/renderer.py
+++ b/mbcdisasm/ast/renderer.py
@@ -1,0 +1,79 @@
+"""Text renderer for :mod:`mbcdisasm.ast` structures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+from .model import ASTBlock, ASTDominatorInfo, ASTFunction, ASTLoop, ASTProgram
+
+
+class ASTRenderer:
+    """Render :class:`ASTProgram` instances into a stable textual form."""
+
+    def render(self, program: ASTProgram) -> str:
+        lines: List[str] = []
+        for function in program.functions:
+            lines.extend(self._render_function(function))
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def write(self, program: ASTProgram, output_path: Path) -> None:
+        output_path.write_text(self.render(program), "utf-8")
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _render_function(self, function: ASTFunction) -> Iterable[str]:
+        header = (
+            f"function segment={function.segment_index} name={function.name} "
+            f"entry={function.entry}"
+        )
+        yield header
+        for block in function.blocks:
+            yield from self._render_block(block)
+        yield from self._render_dom_info("dominators", function.dominators)
+        yield from self._render_dom_info("post_dominators", function.post_dominators)
+        yield from self._render_loops(function.loops)
+        yield ""
+
+    def _render_block(self, block: ASTBlock) -> Iterable[str]:
+        preds = ", ".join(block.predecessors) or "-"
+        succs = ", ".join(block.successors) or "-"
+        yield (
+            f"  block {block.label} offset=0x{block.start_offset:06X} "
+            f"preds=[{preds}] succs=[{succs}]"
+        )
+        for node in block.body:
+            describe = getattr(node, "describe", None)
+            if callable(describe):
+                yield f"    {describe()}"
+            else:
+                yield f"    {node!r}"
+        yield f"    terminator {block.terminator.describe()}"
+
+    def _render_dom_info(
+        self, label: str, infos: Iterable[ASTDominatorInfo]
+    ) -> Iterable[str]:
+        infos = list(infos)
+        if not infos:
+            yield f"  {label}: (empty)"
+            return
+        yield f"  {label}:"
+        for info in infos:
+            dominators = ", ".join(info.dominators)
+            immediate = info.immediate or "-"
+            yield f"    {info.block}: dom=[{dominators}] idom={immediate}"
+
+    def _render_loops(self, loops: Iterable[ASTLoop]) -> Iterable[str]:
+        loops = list(loops)
+        if not loops:
+            yield "  loops: none"
+            return
+        yield "  loops:"
+        for loop in loops:
+            nodes = ", ".join(loop.nodes)
+            latches = ", ".join(loop.latches)
+            yield f"    header={loop.header} nodes=[{nodes}] latches=[{latches}]"
+
+
+__all__ = ["ASTRenderer"]

--- a/tests/test_ast_builder.py
+++ b/tests/test_ast_builder.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from mbcdisasm import ASTBuilder
+from mbcdisasm.ir.model import IRBlock, IRIf, IRProgram, IRReturn, IRSegment, NormalizerMetrics
+
+
+def build_program(blocks: tuple[IRBlock, ...]) -> IRProgram:
+    segment = IRSegment(index=0, start=0, length=0, blocks=blocks, metrics=NormalizerMetrics())
+    return IRProgram(segments=(segment,), metrics=NormalizerMetrics())
+
+
+def test_ast_builder_structures_cfg() -> None:
+    blocks = (
+        IRBlock("entry", 0x0000, (IRIf("cond", 0x0010, 0x0020),)),
+        IRBlock("then", 0x0010, (IRIf("b", 0x0030, 0x0040),)),
+        IRBlock("fold", 0x0020, (IRIf("fold", 0x0030, 0x0030),)),
+        IRBlock("join", 0x0030, (IRIf("join", 0x0040, 0x0050),)),
+        IRBlock("ret1", 0x0040, (IRReturn(("v1",),),)),
+        IRBlock("ret2", 0x0050, (IRReturn(("v2",),),)),
+        IRBlock("dead", 0x0060, (IRReturn(("dead",),),)),
+    )
+    program = build_program(blocks)
+
+    builder = ASTBuilder()
+    ast_program = builder.build(program)
+
+    assert len(ast_program.functions) == 1
+    function = ast_program.functions[0]
+    labels = {block.label for block in function.blocks}
+
+    assert "dead" not in labels, "unreachable block should be eliminated"
+
+    fold_block = next(block for block in function.blocks if block.label == "fold")
+    assert fold_block.terminator.kind == "jump"
+
+    assert any(block.label.startswith("then_split") for block in function.blocks)
+    assert any(block.label.startswith("join_split") for block in function.blocks)
+
+    ret1_block = next(block for block in function.blocks if block.label == "ret1")
+    assert all(pred.startswith("then_split") or pred.startswith("join_split") for pred in ret1_block.predecessors)
+
+    dom_map = {info.block: set(info.dominators) for info in function.dominators}
+    assert dom_map["entry"] == {"entry"}
+    assert "entry" in dom_map["then"]
+
+
+def test_ast_builder_detects_loops() -> None:
+    blocks = (
+        IRBlock("entry", 0x0000, (IRIf("loop", 0x0010, 0x0030),)),
+        IRBlock("loop_header", 0x0010, (IRIf("cond", 0x0020, 0x0030),)),
+        IRBlock("loop_body", 0x0020, (IRIf("body", 0x0010, 0x0030),)),
+        IRBlock("exit", 0x0030, (IRReturn(("done",),),)),
+    )
+    program = build_program(blocks)
+
+    builder = ASTBuilder()
+    ast_program = builder.build(program)
+    function = ast_program.functions[0]
+
+    loops = {loop.header: loop for loop in function.loops}
+    assert "loop_header" in loops
+    loop = loops["loop_header"]
+    loop_nodes = set(loop.nodes)
+    assert {"loop_body", "loop_header"}.issubset(loop_nodes)
+    assert any(latch.startswith("loop_body") for latch in loop.latches)
+
+    dom_map = {info.block: set(info.dominators) for info in function.dominators}
+    assert dom_map["loop_body"].issuperset({"entry", "loop_header", "loop_body"})
+
+    post_dom_map = {info.block: set(info.dominators) for info in function.post_dominators}
+    assert "exit" in post_dom_map["entry"]
+    assert "exit" in post_dom_map["loop_body"]


### PR DESCRIPTION
## Summary
- add a dedicated `mbcdisasm.ast` package with datamodel, builder, and renderer for the AST phase
- construct structured CFGs that compute dominator/post-dominator trees, natural loops, and remove critical edges
- expose the AST phase through the public API and cover it with unit tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd9f0d4f4832f9472a97dd65a8658)