### PR TITLE
Collapse auto_0 bank trampolines into an AST template

### DIFF
--- a/mbcdisasm/ast/__init__.py
+++ b/mbcdisasm/ast/__init__.py
@@ -1,7 +1,15 @@
 """Public exports for the AST reconstruction stage."""
 
 from .builder import ASTBuilder
-from .model import ASTBlock, ASTFunction, ASTLoop, ASTProgram, ASTTerminator, DominatorInfo
+from .model import (
+    ASTBlock,
+    ASTFunction,
+    ASTFunctionAlias,
+    ASTLoop,
+    ASTProgram,
+    ASTTerminator,
+    DominatorInfo,
+)
 from .renderer import ASTRenderer
 
 __all__ = [
@@ -11,6 +19,7 @@ __all__ = [
     "ASTFunction",
     "ASTBlock",
     "ASTLoop",
+    "ASTFunctionAlias",
     "ASTTerminator",
     "DominatorInfo",
 ]

--- a/mbcdisasm/ast/model.py
+++ b/mbcdisasm/ast/model.py
@@ -54,6 +54,16 @@ class ASTBlock:
 
 
 @dataclass(frozen=True)
+class ASTFunctionAlias:
+    """Summary of an additional function instance folded into a template."""
+
+    name: str
+    segment_index: int
+    entry_block: str
+    entry_offset: int
+
+
+@dataclass(frozen=True)
 class DominatorInfo:
     """Summary of a dominator/post-dominator tree."""
 
@@ -97,6 +107,7 @@ class ASTFunction:
     dominators: DominatorInfo
     post_dominators: DominatorInfo
     loops: Tuple[ASTLoop, ...]
+    aliases: Tuple[ASTFunctionAlias, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/mbcdisasm/ast/renderer.py
+++ b/mbcdisasm/ast/renderer.py
@@ -29,6 +29,14 @@ class ASTRenderer:
             f"entry={function.entry_block} offset=0x{function.entry_offset:04X}"
         )
         lines.append(header)
+        if function.aliases:
+            lines.append("  aliases:")
+            for alias in function.aliases:
+                lines.append(
+                    "    "
+                    f"{alias.name} segment={alias.segment_index} "
+                    f"entry={alias.entry_block} offset=0x{alias.entry_offset:04X}"
+                )
         lines.append("  blocks:")
         for block in function.blocks:
             self._render_block(block, lines)


### PR DESCRIPTION
## Summary
- detect the recurring auto_0 bank initialisation trampoline while building the AST and fold clones into a shared template with alias metadata
- expose function alias information via the AST model and renderer
- add a regression test that covers the template folding logic

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691121fd7524832f84a308b54a38d6c9)