### PR TITLE
Collapse auto-generated bank trampolines into a template

### DIFF
--- a/mbcdisasm/ast/__init__.py
+++ b/mbcdisasm/ast/__init__.py
@@ -1,7 +1,15 @@
 """Public exports for the AST reconstruction stage."""
 
 from .builder import ASTBuilder
-from .model import ASTBlock, ASTFunction, ASTLoop, ASTProgram, ASTTerminator, DominatorInfo
+from .model import (
+    ASTBlock,
+    ASTFunction,
+    ASTFunctionAlias,
+    ASTLoop,
+    ASTProgram,
+    ASTTerminator,
+    DominatorInfo,
+)
 from .renderer import ASTRenderer
 
 __all__ = [
@@ -9,6 +17,7 @@ __all__ = [
     "ASTRenderer",
     "ASTProgram",
     "ASTFunction",
+    "ASTFunctionAlias",
     "ASTBlock",
     "ASTLoop",
     "ASTTerminator",

--- a/mbcdisasm/ast/model.py
+++ b/mbcdisasm/ast/model.py
@@ -86,6 +86,15 @@ class ASTLoop:
 
 
 @dataclass(frozen=True)
+class ASTFunctionAlias:
+    """Alias that points back to the original auto-generated entry point."""
+
+    name: str
+    entry_block: str
+    entry_offset: int
+
+
+@dataclass(frozen=True)
 class ASTFunction:
     """High level representation of a single function."""
 
@@ -97,6 +106,7 @@ class ASTFunction:
     dominators: DominatorInfo
     post_dominators: DominatorInfo
     loops: Tuple[ASTLoop, ...]
+    aliases: Tuple[ASTFunctionAlias, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/mbcdisasm/ast/renderer.py
+++ b/mbcdisasm/ast/renderer.py
@@ -28,6 +28,11 @@ class ASTRenderer:
             f"function {function.name} segment={function.segment_index} "
             f"entry={function.entry_block} offset=0x{function.entry_offset:04X}"
         )
+        if function.aliases:
+            aliases = ", ".join(
+                f"{alias.name}@0x{alias.entry_offset:04X}" for alias in function.aliases
+            )
+            header += f" aliases=[{aliases}]"
         lines.append(header)
         lines.append("  blocks:")
         for block in function.blocks:


### PR DESCRIPTION
## Summary
- add ASTFunctionAlias metadata and export it through the AST renderer
- collapse duplicate auto_ trampolines into a shared bank-init template during AST building
- cover the collapse behaviour with a dedicated AST builder test

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691121fd7524832f84a308b54a38d6c9)